### PR TITLE
Allow cursor to be moved

### DIFF
--- a/stylesheets/main.scss
+++ b/stylesheets/main.scss
@@ -235,7 +235,7 @@ body, pre {
   // To display even empty rows. The height might need tweaking.
   // TODO: Remove if we always have a fixed buffer width.
   .row {
-    height: $font-size + 4px;
+    min-height: $font-size + 4px;
   }
 }
 

--- a/views/main.js
+++ b/views/main.js
@@ -9,6 +9,8 @@ var keys = {
     goDown: event => (event.ctrlKey && event.keyCode === 78) || event.keyCode === 40,
     enter: event => event.keyCode === 13,
     tab: event => event.keyCode === 9,
+    left: event => event.keyCode === 37,
+    right: event => event.keyCode === 39,
     deleteWord: event => event.ctrlKey && event.keyCode === 87,
     interrupt: event => event.ctrlKey && event.keyCode === 67
 };
@@ -87,6 +89,10 @@ function isShellHandledKey(event) {
 
 const isDefinedKey = _.memoize(event => _.some(_.values(keys), matcher => matcher(event)),
                                event => [event.ctrlKey, event.keyCode]);
+
+function isArrowKey(event) {
+    return keys.left(event) || keys.right(event);
+}
 
 function stopBubblingUp(event) {
     event.stopPropagation();

--- a/views/prompt.js
+++ b/views/prompt.js
@@ -62,9 +62,11 @@ export default React.createClass({
             return;
         }
 
+        var newCaretPosition = getCaretPosition();
         this.refs.command.innerText = this.getText();
 
-        if (this.state.caretPosition !== getCaretPosition() || prevState.caretOffset !== this.state.caretOffset) {
+        if (this.state.caretPosition !== newCaretPosition || prevState.caretOffset !== this.state.caretOffset) {
+            this.state.caretPosition = newCaretPosition;
             setCaretPosition(this.refs.command, this.state.caretPosition);
         }
 

--- a/views/prompt.js
+++ b/views/prompt.js
@@ -35,6 +35,7 @@ export default React.createClass({
             .forEach(event => this.setState({latestKeyCode: event.keyCode}));
 
         promptKeys.filter(keys.enter).forEach(this.execute);
+        promptKeys.filter(isArrowKey).forEach(this.handleArrowKey);
 
         meaningfulKeysDownStream.filter(this.autocompleteIsShown)
             .filter(keys.tab)
@@ -62,11 +63,9 @@ export default React.createClass({
             return;
         }
 
-        var newCaretPosition = getCaretPosition();
         this.refs.command.innerText = this.getText();
 
-        if (this.state.caretPosition !== newCaretPosition || prevState.caretOffset !== this.state.caretOffset) {
-            this.state.caretPosition = newCaretPosition;
+        if (this.state.caretPosition !== getCaretPosition() || prevState.caretOffset !== this.state.caretOffset) {
             setCaretPosition(this.refs.command, this.state.caretPosition);
         }
 
@@ -160,6 +159,19 @@ export default React.createClass({
         if (this.props.status === 'in-progress') {
             stopBubblingUp(event);
         }
+    },
+    handleArrowKey(event) {
+        var position = this.state.caretPosition;
+
+        if (keys.left(event) && position > 0) {
+            --position;
+        } else if (keys.right(event) && position < this.getText().length - 1) {
+            ++position;
+        } else {
+          return;
+        }
+
+        this.setState({caretPosition: position});
     },
     showAutocomplete() {
         //TODO: use streams.


### PR DESCRIPTION
I’m unable to move the cursor away from the end of the line. This issue was reported in #141, but it looks like it was only partially resolved in that ticket.

Changes:
- Move the cursor left and right when the arrow keys are pressed

EDIT: Oops, this PR broke the cursor being positioned by setting the state. I'll work on fixing this.
EDIT 2: Should be fixed now. I updated the changes list above.