### PR TITLE
Add fixPath() to Main.ts, allows correct $PATH on OSX

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   ],
   "electronVersion": "0.35.0",
   "dependencies": {
+    "fix-path": "1.1.0",
     "fixed-sticky": "^0.1.6",
     "font-awesome": "4.4.0",
     "fuzzaldrin": "2.1.0",

--- a/src/main/Main.ts
+++ b/src/main/Main.ts
@@ -2,8 +2,12 @@ const app = require('app');
 const BrowserWindow = require('browser-window');
 const IPC = require('electron').ipcMain;
 let menu = require('./Menu');
+let fixPath = require('fix-path');
 
 let browserWindow: any = null;
+
+// Fix the $PATH on OS X
+fixPath();
 
 app.on('open-file', (event: Event, file: string) => getMainWindow().webContents.send('change-working-directory', file))
     .on('ready', getMainWindow)


### PR DESCRIPTION
Fixes #50 

I tested this locally and it seems to work. 

I've never used TypeScript before, so I hope this is the correct approach. Please let me know if it isn't!