### PR TITLE
Fix spelling on SuggestionCompoonent

### DIFF
--- a/src/views/AutocompleteComponent.ts
+++ b/src/views/AutocompleteComponent.ts
@@ -12,7 +12,7 @@ interface AutocompleteProps {
 export default class AutocompleteComponent extends React.Component<AutocompleteProps, {}> {
     render() {
         const suggestionViews = this.props.suggestions.map((suggestion, index) => {
-            return React.createElement(SuggestionCompoonent, {
+            return React.createElement(SuggestionComponent, {
                 suggestion: suggestion,
                 key: index,
                 isHighlighted: index === this.props.highlightedIndex
@@ -42,7 +42,7 @@ interface SuggestionProps {
     isHighlighted: boolean;
 }
 
-class SuggestionCompoonent extends React.Component<SuggestionProps, {}> {
+class SuggestionComponent extends React.Component<SuggestionProps, {}> {
     render() {
         const scoreStyle = window.DEBUG ? {} : { display: 'none' };
         let classes = [this.props.suggestion.type];


### PR DESCRIPTION
While I was hacking away on adding clickable suggestions, I noticed the misspelling in `SuggestionCompoonent`.
Is there any reason why it was named that way ? 
Anyway, this PR renames the React component `SuggestionCompoonent` to `SuggestionComponent`
I've run ag on the codebase to make sure I caught all occurences. Looks like the component is not used outside of this single file. 