### PR TITLE
Add clickable suggestions for AutocompleteComponent

### DIFF
--- a/src/views/4_PromptComponent.ts
+++ b/src/views/4_PromptComponent.ts
@@ -181,6 +181,7 @@ export default class PromptComponent extends React.Component<Props, State> imple
                 suggestions: this.state.suggestions,
                 caretOffset: this.state.caretOffset,
                 onSelectedSuggestion: this.selectSuggestion.bind(this),
+                onClickedSuggestion: this.selectAutocomplete.bind(this),
                 highlightedIndex: this.state.highlightedSuggestionIndex,
                 ref: 'autocomplete'
             });
@@ -275,7 +276,6 @@ export default class PromptComponent extends React.Component<Props, State> imple
     
     private selectSuggestion(i: number): void {
         this.setState({highlightedSuggestionIndex: i});
-
     }
 
     private navigateAutocomplete(event: KeyboardEvent): void {

--- a/src/views/4_PromptComponent.ts
+++ b/src/views/4_PromptComponent.ts
@@ -180,8 +180,8 @@ export default class PromptComponent extends React.Component<Props, State> imple
             var autocomplete = React.createElement(AutocompleteComponent, {
                 suggestions: this.state.suggestions,
                 caretOffset: this.state.caretOffset,
-                onSelectedSuggestion: this.selectSuggestion.bind(this),
-                onClickedSuggestion: this.selectAutocomplete.bind(this),
+                onHoverSuggestion: this.selectSuggestion.bind(this),
+                onClickSuggestion: this.selectAutocomplete.bind(this),
                 highlightedIndex: this.state.highlightedSuggestionIndex,
                 ref: 'autocomplete'
             });

--- a/src/views/4_PromptComponent.ts
+++ b/src/views/4_PromptComponent.ts
@@ -271,6 +271,10 @@ export default class PromptComponent extends React.Component<Props, State> imple
             this.replaceText(History.getNext());
         }
     }
+    
+    private selectSuggestion(i: number): void {
+        this.setState({highlightedSuggestionIndex: i});
+    }
 
     private navigateAutocomplete(event: KeyboardEvent): void {
         if (keys.goUp(event)) {
@@ -279,7 +283,7 @@ export default class PromptComponent extends React.Component<Props, State> imple
             index = Math.min(this.state.suggestions.length - 1, this.state.highlightedSuggestionIndex + 1)
         }
 
-        this.setState({ highlightedSuggestionIndex: index });
+        this.selectSuggestion(index)
     }
 
     private selectAutocomplete(): void {

--- a/src/views/4_PromptComponent.ts
+++ b/src/views/4_PromptComponent.ts
@@ -180,6 +180,7 @@ export default class PromptComponent extends React.Component<Props, State> imple
             var autocomplete = React.createElement(AutocompleteComponent, {
                 suggestions: this.state.suggestions,
                 caretOffset: this.state.caretOffset,
+                onSelectedSuggestion: this.selectSuggestion.bind(this),
                 highlightedIndex: this.state.highlightedSuggestionIndex,
                 ref: 'autocomplete'
             });
@@ -274,6 +275,7 @@ export default class PromptComponent extends React.Component<Props, State> imple
     
     private selectSuggestion(i: number): void {
         this.setState({highlightedSuggestionIndex: i});
+
     }
 
     private navigateAutocomplete(event: KeyboardEvent): void {

--- a/src/views/AutocompleteComponent.ts
+++ b/src/views/AutocompleteComponent.ts
@@ -6,8 +6,8 @@ type Offset = {top: number, left: number, bottom: number};
 interface AutocompleteProps {
     caretOffset: Offset;
     suggestions: Suggestion[];
-    onSelectedSuggestion: Function;
-    onClickedSuggestion: Function;
+    onHoverSuggestion: Function;
+    onClickSuggestion: Function;
     highlightedIndex: number;
 }
 
@@ -16,8 +16,8 @@ export default class AutocompleteComponent extends React.Component<AutocompleteP
         const suggestionViews = this.props.suggestions.map((suggestion, index) => {
             return React.createElement(SuggestionCompoonent, {
                 suggestion: suggestion,
-                onSelectedSuggestion: this.props.onSelectedSuggestion.bind(this, index),
-                onClickedSuggestion: this.props.onClickedSuggestion,
+                onHoverSuggestion: this.props.onHoverSuggestion.bind(this, index),
+                onClickSuggestion: this.props.onClickSuggestion,
                 key: index,
                 isHighlighted: index === this.props.highlightedIndex
             });
@@ -43,8 +43,8 @@ export default class AutocompleteComponent extends React.Component<AutocompleteP
 interface SuggestionProps {
     suggestion: Suggestion;
     key: number;
-    onSelectedSuggestion: Function;
-    onClickedSuggestion: Function
+    onHoverSuggestion: Function;
+    onClickSuggestion: Function
     isHighlighted: boolean;
 }
 
@@ -59,7 +59,7 @@ class SuggestionCompoonent extends React.Component<SuggestionProps, {}> {
             classes.push('highlighted');
         }
 
-        return React.createElement('li', { className: classes.join(' '), style: suggestionStyle, onMouseOver: this.props.onSelectedSuggestion, onClick: this.props.onClickedSuggestion},
+        return React.createElement('li', { className: classes.join(' '), style: suggestionStyle, onMouseOver: this.props.onHoverSuggestion, onClick: this.props.onClickSuggestion},
             React.createElement('i', { className: 'icon' }),
             React.createElement('span', { className: 'value' }, this.props.suggestion.value),
             React.createElement('span', {

--- a/src/views/AutocompleteComponent.ts
+++ b/src/views/AutocompleteComponent.ts
@@ -6,14 +6,16 @@ type Offset = {top: number, left: number, bottom: number};
 interface AutocompleteProps {
     caretOffset: Offset;
     suggestions: Suggestion[];
+    onSelectedSuggestion: Function;
     highlightedIndex: number;
 }
 
-export default class AutocompleteComponent extends React.Component<AutocompleteProps, {}> {
+export default class AutocompleteComponent extends React.Component<AutocompleteProps, {}> { 
     render() {
         const suggestionViews = this.props.suggestions.map((suggestion, index) => {
             return React.createElement(SuggestionCompoonent, {
                 suggestion: suggestion,
+                onSelectedSuggestion: this.props.onSelectedSuggestion.bind(this, index),
                 key: index,
                 isHighlighted: index === this.props.highlightedIndex
             });
@@ -39,6 +41,7 @@ export default class AutocompleteComponent extends React.Component<AutocompleteP
 interface SuggestionProps {
     suggestion: Suggestion;
     key: number;
+    onSelectedSuggestion: Function;
     isHighlighted: boolean;
 }
 
@@ -51,7 +54,7 @@ class SuggestionCompoonent extends React.Component<SuggestionProps, {}> {
             classes.push('highlighted');
         }
 
-        return React.createElement('li', { className: classes.join(' ') },
+        return React.createElement('li', { className: classes.join(' '), onMouseOver: this.props.onSelectedSuggestion},
             React.createElement('i', { className: 'icon' }),
             React.createElement('span', { className: 'value' }, this.props.suggestion.value),
             React.createElement('span', {

--- a/src/views/AutocompleteComponent.ts
+++ b/src/views/AutocompleteComponent.ts
@@ -7,6 +7,7 @@ interface AutocompleteProps {
     caretOffset: Offset;
     suggestions: Suggestion[];
     onSelectedSuggestion: Function;
+    onClickedSuggestion: Function;
     highlightedIndex: number;
 }
 
@@ -16,6 +17,7 @@ export default class AutocompleteComponent extends React.Component<AutocompleteP
             return React.createElement(SuggestionCompoonent, {
                 suggestion: suggestion,
                 onSelectedSuggestion: this.props.onSelectedSuggestion.bind(this, index),
+                onClickedSuggestion: this.props.onClickedSuggestion,
                 key: index,
                 isHighlighted: index === this.props.highlightedIndex
             });
@@ -42,6 +44,7 @@ interface SuggestionProps {
     suggestion: Suggestion;
     key: number;
     onSelectedSuggestion: Function;
+    onClickedSuggestion: Function
     isHighlighted: boolean;
 }
 
@@ -54,7 +57,7 @@ class SuggestionCompoonent extends React.Component<SuggestionProps, {}> {
             classes.push('highlighted');
         }
 
-        return React.createElement('li', { className: classes.join(' '), onMouseOver: this.props.onSelectedSuggestion},
+        return React.createElement('li', { className: classes.join(' '), onMouseOver: this.props.onSelectedSuggestion, onClick: this.props.onClickedSuggestion},
             React.createElement('i', { className: 'icon' }),
             React.createElement('span', { className: 'value' }, this.props.suggestion.value),
             React.createElement('span', {

--- a/src/views/AutocompleteComponent.ts
+++ b/src/views/AutocompleteComponent.ts
@@ -51,13 +51,15 @@ interface SuggestionProps {
 class SuggestionCompoonent extends React.Component<SuggestionProps, {}> {
     render() {
         const scoreStyle = window.DEBUG ? {} : { display: 'none' };
+        const suggestionStyle = { cursor: "pointer" }
+        
         let classes = [this.props.suggestion.type];
 
         if (this.props.isHighlighted) {
             classes.push('highlighted');
         }
 
-        return React.createElement('li', { className: classes.join(' '), onMouseOver: this.props.onSelectedSuggestion, onClick: this.props.onClickedSuggestion},
+        return React.createElement('li', { className: classes.join(' '), style: suggestionStyle, onMouseOver: this.props.onSelectedSuggestion, onClick: this.props.onClickedSuggestion},
             React.createElement('i', { className: 'icon' }),
             React.createElement('span', { className: 'value' }, this.props.suggestion.value),
             React.createElement('span', {


### PR DESCRIPTION
This does three main things:
1) Hovering a suggestion changes `highlightedSuggestionIndex`.
2) A click on a suggestion calls `selectAutocomplete()` (i.e it autocompletes the input with the clicked suggestion)
3) `suggestionComponent` is now styled with `{cursor: "pointer"}` so it actually looks clickable.

Any thoughts ? :-)