### PR TITLE
Replace deprecated restart() method with reload()

### DIFF
--- a/src/main/Menu.ts
+++ b/src/main/Menu.ts
@@ -88,7 +88,7 @@ module.exports = {
                             label: 'Reload',
                             accelerator: 'Command+R',
                             click: function () {
-                                browserWindow.restart();
+                                browserWindow.reload();
                             }
                         },
                         {
@@ -153,7 +153,7 @@ module.exports = {
                             label: '&Reload',
                             accelerator: 'Ctrl+R',
                             click: function () {
-                                browserWindow.restart();
+                                browserWindow.reload();
                             }
                         },
                         {


### PR DESCRIPTION
This replace the deprecated `restart()` method with `reload()`.
From what I've seen, they should both behave the same way.
Fix https://github.com/shockone/black-screen/issues/196