### PR TITLE
Modified .gitignore to include Visual Studio Code workplace settings folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# Directory created by Visual Studio Code
+.vscode


### PR DESCRIPTION
Modified the project .gitignore to include the Visual Studio Code (vs code) workplace settings folder.

Vs code uses the .vscode directory to store settings such files as tasks.json and launch.json. See vs code documentation:
https://code.visualstudio.com/Docs/customization/userandworkspace 