### PR TITLE
Removed redundant spaces in commands before adding to session history

### DIFF
--- a/src/History.ts
+++ b/src/History.ts
@@ -1,7 +1,12 @@
 import {lex} from "./CommandExpander";
 
 export class HistoryEntry {
-    constructor(private _raw: string, private _historyExpanded: string[]) {
+    private _raw: string;
+    private _historyExpanded: string[];
+
+    constructor(private entryValue: string, private entryExpanded: string[]) {
+        this._raw = entryValue.trim().replace(/\s+/g, " ");
+        this._historyExpanded = entryExpanded;
     }
 
     get raw(): string {


### PR DESCRIPTION
This change removes leading, trailing and multiple spaces from commands before they are added to session history.