### PR TITLE
Filtered out suggestion items whose score is zero

### DIFF
--- a/src/Autocompletion.ts
+++ b/src/Autocompletion.ts
@@ -15,9 +15,12 @@ export default class Autocompletion implements i.AutocompletionProvider {
         return Promise.all(providers.map(provider => provider.getSuggestions(job))).then(results =>
             _._(results)
                 .flatten()
+                // .forEach((suggestion: Suggestion) =>
+                //         suggestion.score = score(suggestion.value, suggestion.getPrefix(job))
+                // )
                 .filter((suggestion: Suggestion) =>
-                    !suggestion.shouldIgnore(job) &&
-                    score(suggestion.value, suggestion.getPrefix(job)) > 0)
+                        !suggestion.shouldIgnore(job) &&
+                        score(suggestion.value, suggestion.getPrefix(job)) > 0)
                 .sortBy((suggestion: Suggestion) => -score(suggestion.value, suggestion.getPrefix(job)))
                 .uniqBy((suggestion: Suggestion) => suggestion.value)
                 .take(Autocompletion.limit)

--- a/src/Autocompletion.ts
+++ b/src/Autocompletion.ts
@@ -12,11 +12,12 @@ export default class Autocompletion implements i.AutocompletionProvider {
         let specializedProviders = PluginManager.specializedAutocompletionProviders(job.prompt.expandedFinishedLexemes);
         let providers = specializedProviders.length ? specializedProviders : PluginManager.genericAutocompletionProviders;
 
-        // FIXME: skip suggestions that have 0 score.
         return Promise.all(providers.map(provider => provider.getSuggestions(job))).then(results =>
             _._(results)
                 .flatten()
-                .filter((suggestion: Suggestion) => !suggestion.shouldIgnore(job))
+                .filter((suggestion: Suggestion) =>
+                    !suggestion.shouldIgnore(job) &&
+                    score(suggestion.value, suggestion.getPrefix(job)) > 0)
                 .sortBy((suggestion: Suggestion) => -score(suggestion.value, suggestion.getPrefix(job)))
                 .uniqBy((suggestion: Suggestion) => suggestion.value)
                 .take(Autocompletion.limit)

--- a/src/plugins/autocompletion_providers/Suggestions.ts
+++ b/src/plugins/autocompletion_providers/Suggestions.ts
@@ -12,6 +12,7 @@ export class Suggestion {
     private _description: string;
     private _type: string;
     private _childrenProvider: (job: Job) => SuggestionsPromise;
+    private _score: number;
 
     constructor() {
         this._value = "";
@@ -47,6 +48,14 @@ export class Suggestion {
 
     get displayValue(): string {
         return this.value;
+    }
+
+    get score(): number {
+        return this._score;
+    }
+
+    set score(v: number) {
+        this._score = v;
     }
 
     getPrefix(job: Job): string {


### PR DESCRIPTION
Removed items with a (fuzzy) score of zero from the autocomplete suggestions list.

This change is to address the FIXME comment in https://github.com/shockone/black-screen/blob/master/src/Autocompletion.ts#l15