### PR TITLE
Tab command history fix

### DIFF
--- a/src/views/1_ApplicationComponent.tsx
+++ b/src/views/1_ApplicationComponent.tsx
@@ -72,7 +72,7 @@ export default class ApplicationComponent extends React.Component<{}, State> {
             }
         }
 
-        if (event.metaKey && event.keyCode === KeyCode.T) {
+        if ((event.metaKey || event.ctrlKey) && event.keyCode === KeyCode.T) {
             if (this.tabs.length < 9) {
                 this.addTab();
                 this.setState({sessions: this.activeTab.sessions});

--- a/src/views/4_PromptComponent.tsx
+++ b/src/views/4_PromptComponent.tsx
@@ -163,6 +163,11 @@ export default class PromptComponent extends React.Component<Props, State> imple
             scrollToTop = <a className="scroll-to-top" onClick={this.handleScrollToTop.bind(this)}><i className="fa fa-long-arrow-up"/></a>;
         }
 
+        let contentEditable: boolean = this.props.status === e.Status.NotStarted ||
+             this.props.status === e.Status.InProgress;
+        let promptValue: String;
+        { contentEditable ? promptValue = "" : promptValue = this.prompt.value; }
+
         return (
             <div className={classes}>
                 <div className="arrow"></div>
@@ -173,7 +178,9 @@ export default class PromptComponent extends React.Component<Props, State> imple
                      onKeyPress={this.handleKeyPress.bind(this)}
                      type="text"
                      ref="command"
-                     contentEditable={this.props.status === e.Status.NotStarted || this.props.status === e.Status.InProgress}></div>
+                     contentEditable={contentEditable}>
+                    {promptValue}
+                </div>
                 {autocompletedPreview}
                 {inlineSynopsis}
                 {autocomplete}


### PR DESCRIPTION
This change addresses issue #280 where individual commands are no longer displayed after switching tabs.