### PR TITLE
Fix wrong font in output cut messages

### DIFF
--- a/stylesheets/main.scss
+++ b/stylesheets/main.scss
@@ -326,9 +326,9 @@ body, pre {
 
     &:before {
       margin-right: 10px;
+      @extend .octicon;
+      @extend .octicon-unfold;
     }
-    @extend .octicon;
-    @extend .octicon-unfold;
 
     position: relative;
     top: -10px;


### PR DESCRIPTION
Extending `.octicon` in `.output-cut` made non-icon text to not inherit proper font, using system's default.
With this fix `.output-cut:before` extends `.output-cut` so icon is properly displayed but the rest of the text inherits proper font as expected.