### PR TITLE
Tab name functionality

### DIFF
--- a/src/views/TabComponent.tsx
+++ b/src/views/TabComponent.tsx
@@ -16,7 +16,8 @@ export interface TabProps {
 export enum TabHoverState {
     Nothing,
     Tab,
-    Close
+    Close,
+    Edit
 }
 
 interface TabState {
@@ -24,9 +25,36 @@ interface TabState {
 }
 
 export class TabComponent extends React.Component<TabProps, TabState> {
+
+    refs: {
+        [key: string]: (Element);
+        tabName: (HTMLInputElement);
+    };
+
     constructor() {
         super();
         this.state = {hover: TabHoverState.Nothing};
+    }
+
+    changeTabNameHandler(event: KeyboardEvent): KeyboardEvent {
+        let activeTabName = this.refs.tabName;
+        activeTabName.disabled = false;
+        activeTabName.style.textOverflow = "none";
+        activeTabName.title = "";
+        activeTabName.focus();
+        return event;
+    }
+
+    disableTabNameHandler(event: KeyboardEvent): KeyboardEvent {
+        let activeTabName = this.refs.tabName;
+        activeTabName.disabled = true;
+        activeTabName.style.textOverflow = "ellipsis";
+        if (activeTabName.offsetWidth < activeTabName.scrollWidth) {
+            activeTabName.title = activeTabName.value;
+        } else {
+            activeTabName.title = "";
+        }
+        return event;
     }
 
     render() {
@@ -41,6 +69,15 @@ export class TabComponent extends React.Component<TabProps, TabState> {
                   onMouseLeave={() => this.setState({hover: TabHoverState.Tab})}/>
             <span style={css.commandSign}>⌘</span>
             <span>{this.props.position}</span>
+            <input type="text" ref="tabName"
+                  style={css.tabName()}
+                  disabled="disabled"
+                  onBlur={this.disableTabNameHandler.bind(this)}/>
+            <span style={css.editName(this.state.hover === TabHoverState.Edit, this.props.isActive)}
+                  dangerouslySetInnerHTML={{__html: fontAwesome.edit}}
+                  onClick={this.changeTabNameHandler.bind(this)}
+                  onMouseEnter={() => this.setState({hover: TabHoverState.Edit})}
+                  onMouseLeave={() => this.setState({hover: TabHoverState.Tab})}/>
         </li>;
     }
 }

--- a/src/views/css/main.ts
+++ b/src/views/css/main.ts
@@ -327,6 +327,32 @@ export const tabClose = (hover: TabHoverState) => {
     );
 };
 
+export const tabName = () => {
+    return {
+        paddingLeft: 5,
+        backgroundColor: "transparent",
+        color: colors.white,
+        borderColor: "transparent",
+        width: "45%",
+        borderStyle: "solid",
+        borderWidth: 1,
+    };
+};
+
+export const editName = (hoverEdit: boolean, isActive: boolean) => {
+    return Object.assign(
+        {},
+        icon,
+        {
+            width: "7%",
+            paddingLeft: 3,
+            fontSize: fontSize - 1,
+            color: hoverEdit ? colors.blue : colors.white,
+            cursor: hoverEdit ? "pointer" : "default",
+            visibility: isActive ? "visible" : "hidden",
+        });
+    };
+
 export const commandSign = {
     fontSize: fontSize + 3,
     verticalAlign: "middle",


### PR DESCRIPTION
Added functionality to edit tab  #name. Where tab names are longer than the field width the name is truncated and a tooltip shown.
Note, the user can only edit the tab name on the active-tab. 