### PR TITLE
Fix issue with relative path

### DIFF
--- a/src/CommandExecutor.ts
+++ b/src/CommandExecutor.ts
@@ -40,7 +40,8 @@ class ShellExecutionStrategy extends CommandExecutionStrategy {
     static async canExecute(job: Job) {
         return loginShell.preCommandModifiers.includes(job.prompt.commandName) ||
             await this.isExecutableFromPath(job) ||
-            await this.isPathOfExecutable(job);
+            await this.isPathOfExecutable(job) ||
+            this.isValidPath(job.prompt.commandName);
     }
 
     private static async isExecutableFromPath(job: Job): Promise<boolean> {
@@ -49,6 +50,10 @@ class ShellExecutionStrategy extends CommandExecutionStrategy {
 
     private static async isPathOfExecutable(job: Job): Promise<boolean> {
         return await exists(resolveFile(job.session.directory, job.prompt.commandName));
+    }
+    
+    private static isValidPath(commandName: string): boolean {
+        return  !(/[*!?{}(|)[\]]/.test(commandName) || /[@?!+*]\(/.test(commandName) || /[‘“!#$%&+^<=>`]/.test(commandName))
     }
 
     startExecution() {


### PR DESCRIPTION
If file is existing it is trying to execute the command using `ShellExecutionStrategy`, but if not we don't pass this command to any Strategy. My proposition is to check is this command has correct path format, and if so - execute it by `ShellExecutionStrategy`. If not - just go to the next available Strategy.