### PR TITLE
Fixing Common.stat method to accept a broken symlink.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,11 +44,13 @@
   "devDependencies": {
     "@types/chai": "3.4.22-alpha",
     "@types/mocha": "2.2.21-alpha",
+    "@types/mock-fs": "3.6.22-alpha",
     "chai": "3.5.0",
     "devtron": "1.2.1",
     "electron-builder": "5.7.0",
     "electron-prebuilt": "1.2.5",
     "mocha": "2.5.3",
+    "mock-fs": "3.9.0",
     "npm-check-updates": "2.6.7",
     "spectron": "3.2.3",
     "ts-node": "0.9.3",

--- a/src/utils/Common.ts
+++ b/src/utils/Common.ts
@@ -60,7 +60,7 @@ export function recursiveFilesIn(directoryPath: string): Promise<string[]> {
 
 export function stat(filePath: string): Promise<fs.Stats> {
     return new Promise((resolve, reject) => {
-        fs.stat(filePath, (error: NodeJS.ErrnoException, pathStat: fs.Stats) => {
+        fs.lstat(filePath, (error: NodeJS.ErrnoException, pathStat: fs.Stats) => {
             if (error) {
                 reject(error);
             } else {

--- a/src/utils/Common.ts
+++ b/src/utils/Common.ts
@@ -58,7 +58,7 @@ export function recursiveFilesIn(directoryPath: string): Promise<string[]> {
     );
 }
 
-export function stat(filePath: string): Promise<fs.Stats> {
+export function lstat(filePath: string): Promise<fs.Stats> {
     return new Promise((resolve, reject) => {
         fs.lstat(filePath, (error: NodeJS.ErrnoException, pathStat: fs.Stats) => {
             if (error) {
@@ -72,7 +72,7 @@ export function stat(filePath: string): Promise<fs.Stats> {
 
 export async function statsIn(directoryPath: FullPath): Promise<i.FileInfo[]> {
     return Promise.all((await filesIn(directoryPath)).map(async (fileName) => {
-        return {name: fileName, stat: await stat(Path.join(directoryPath, fileName))};
+        return {name: fileName, stat: await lstat(Path.join(directoryPath, fileName))};
     }));
 }
 
@@ -86,7 +86,7 @@ export function exists(filePath: string): Promise<boolean> {
 
 export async function isDirectory(directoryPath: string): Promise<boolean> {
     if (await exists(directoryPath)) {
-        return (await stat(directoryPath)).isDirectory();
+        return (await lstat(directoryPath)).isDirectory();
     } else {
         return false;
     }

--- a/test/utils/common_spec.ts
+++ b/test/utils/common_spec.ts
@@ -1,6 +1,6 @@
 import "mocha";
 import {expect} from "chai";
-import {commonPrefix, stat} from "../../src/utils/Common";
+import {commonPrefix, lstat, resolveFile} from "../../src/utils/Common";
 import * as mockFs from "mock-fs";
 
 
@@ -11,17 +11,15 @@ describe("common utils", () => {
         });
     });
 
-    describe("stat", () => {
+    describe("lstat", () => {
         it("returns stats even if the file is a borken symlink", async() => {
             mockFs({
-                '/broken-symlink': mockFs.symlink({
-                    path: 'non-existing-file'
+                "/broken-symlink": mockFs.symlink({
+                    path: "non-existing-file"
                 })
             });
-            return stat(<FullPath>'/broken-symlink')
-                .then((stats) => {
-                    expect(stats).to.exist;
-                });
+            const stats = await lstat(resolveFile("/", "/broken-symlink"))
+            expect(stats).to.exist;
         });
     });
 });

--- a/test/utils/common_spec.ts
+++ b/test/utils/common_spec.ts
@@ -1,11 +1,27 @@
 import "mocha";
 import {expect} from "chai";
-import {commonPrefix} from "../../src/utils/Common";
+import {commonPrefix, stat} from "../../src/utils/Common";
+import * as mockFs from "mock-fs";
+
 
 describe("common utils", () => {
     describe("commonPrefix", () => {
         it("returns the whole string for the same strings", async() => {
             expect(commonPrefix("abc", "abc")).to.eql("abc");
+        });
+    });
+
+    describe("stat", () => {
+        it("returns stats even if the file is a borken symlink", async() => {
+            mockFs({
+                '/broken-symlink': mockFs.symlink({
+                    path: 'non-existing-file'
+                })
+            });
+            return stat(<FullPath>'/broken-symlink')
+                .then((stats) => {
+                    expect(stats).to.exist;
+                });
         });
     });
 });


### PR DESCRIPTION
- Using lstat method (which is not following symlinks) instead of stat.
- Adding mock-fs test dependency to enable unit test

fixes #533 