### PR TITLE
Added 'Hide Black Screen' and 'Hide Others'  commands #444

### DIFF
--- a/src/main/Menu.ts
+++ b/src/main/Menu.ts
@@ -12,6 +12,24 @@ export const menu = {
                             role: "about",
                         },
                         {
+                            type: "separator",
+                        },
+                        {
+                            label: "Hide Black Screen",
+                            accelerator: "Command+H",
+                            click: function () {
+                                app.hide();
+                            },
+                        },
+                        {
+                            label: "Hide Others",
+                            accelerator: "Alt+Command+H",
+                            role: "hideothers",
+                        },
+                        {
+                            type: "separator",
+                        },
+                        {
                             label: "Quit",
                             accelerator: "Command+Q",
                             click: function () {


### PR DESCRIPTION
Added _'Hide Black Screen'_ and _'Hide Others'_ commands to the menu as well as shortcuts for them: 
**Cmd + H** and **Alt + Cmd + H** respectively. (referencing issue: #444 )

<img width="736" alt="screen shot 2016-07-08 at 8 36 43 pm" src="https://cloud.githubusercontent.com/assets/2731774/16705002/c494bc52-454c-11e6-909a-87f766c46e87.png">
