### PR TITLE
Improve display when pasting multiple lines

### DIFF
--- a/src/views/4_PromptComponent.tsx
+++ b/src/views/4_PromptComponent.tsx
@@ -217,8 +217,6 @@ export class PromptComponent extends React.Component<Props, State> implements Ke
                                 dangerouslySetInnerHTML={{__html: fontAwesome.longArrowUp}}/>;
         }
 
-
-
         return (
             <div className="prompt-placeholder" ref="placeholder" id={this.props.job.id} style={css.promptPlaceholder}>
                 <div className="prompt-wrapper" style={css.promptWrapper(this.props.status, this.state.isSticky)}>

--- a/src/views/4_PromptComponent.tsx
+++ b/src/views/4_PromptComponent.tsx
@@ -47,7 +47,7 @@ export class PromptComponent extends React.Component<Props, State> implements Ke
     private intersectionObserver = new IntersectionObserver(
         (entries) => {
             const entry = entries[0];
-            const nearTop = entry.boundingClientRect.bottom < 100;
+            const nearTop = entry.boundingClientRect.top < 50;
             const isVisible = entry.intersectionRatio === 1;
 
             this.setState(assign(this.state, {isSticky: nearTop && !isVisible}));
@@ -208,12 +208,16 @@ export class PromptComponent extends React.Component<Props, State> implements Ke
             decorationToggle = <DecorationToggleComponent decorateToggler={this.props.decorateToggler}/>;
         }
 
+        let promptCss = Object.assign({}, css.prompt);
         if (this.state.isSticky) {
+            promptCss.whiteSpace = "nowrap";
             scrollToTop = <span style={css.action}
                                 title="Scroll to beginning of output."
                                 onClick={this.handleScrollToTop.bind(this)}
                                 dangerouslySetInnerHTML={{__html: fontAwesome.longArrowUp}}/>;
         }
+
+
 
         return (
             <div className="prompt-placeholder" ref="placeholder" id={this.props.job.id} style={css.promptPlaceholder}>
@@ -225,7 +229,7 @@ export class PromptComponent extends React.Component<Props, State> implements Ke
                          title={JSON.stringify(this.props.status)}
                          dangerouslySetInnerHTML={{__html: this.props.status === Status.Interrupted ? fontAwesome.close : ""}}></div>
                     <div className="prompt"
-                         style={css.prompt}
+                         style={promptCss}
                          onKeyDown={event => this.handlers.onKeyDown(event)}
                          onInput={this.handleInput.bind(this)}
                          onKeyPress={() => this.props.status === e.Status.InProgress && stopBubblingUp(event)}

--- a/src/views/4_PromptComponent.tsx
+++ b/src/views/4_PromptComponent.tsx
@@ -208,9 +208,7 @@ export class PromptComponent extends React.Component<Props, State> implements Ke
             decorationToggle = <DecorationToggleComponent decorateToggler={this.props.decorateToggler}/>;
         }
 
-        let promptCss = Object.assign({}, css.prompt);
         if (this.state.isSticky) {
-            promptCss.whiteSpace = "nowrap";
             scrollToTop = <span style={css.action}
                                 title="Scroll to beginning of output."
                                 onClick={this.handleScrollToTop.bind(this)}
@@ -227,7 +225,7 @@ export class PromptComponent extends React.Component<Props, State> implements Ke
                          title={JSON.stringify(this.props.status)}
                          dangerouslySetInnerHTML={{__html: this.props.status === Status.Interrupted ? fontAwesome.close : ""}}></div>
                     <div className="prompt"
-                         style={promptCss}
+                         style={css.prompt(this.state.isSticky)}
                          onKeyDown={event => this.handlers.onKeyDown(event)}
                          onInput={this.handleInput.bind(this)}
                          onKeyPress={() => this.props.status === e.Status.InProgress && stopBubblingUp(event)}

--- a/src/views/css/definitions.ts
+++ b/src/views/css/definitions.ts
@@ -32,7 +32,7 @@ export interface CSSObject {
     bottom?: number | "auto";
     left?: number;
     right?: number;
-    whiteSpace?: "pre-wrap";
+    whiteSpace?: "pre-wrap" | "nowrap";
     zIndex?: number;
     gridArea?: string;
     display?: "grid" | "inline-block" | "flex";

--- a/src/views/css/main.ts
+++ b/src/views/css/main.ts
@@ -533,7 +533,7 @@ export const prompt = (isSticky: boolean) => Object.assign(
 );
 
 export const promptPlaceholder = {
-    "min-height": promptWrapperHeight,
+    minHeight: promptWrapperHeight,
 };
 
 export const arrowInner = (status: Status) => {

--- a/src/views/css/main.ts
+++ b/src/views/css/main.ts
@@ -522,12 +522,13 @@ export const autocompletedPreview = Object.assign(
     }
 );
 
-export const prompt = Object.assign(
+export const prompt = (isSticky: boolean) => Object.assign(
     {},
     promptInlineElement,
     {
         color: colors.white,
         zIndex: 2,
+        whiteSpace: isSticky ? "nowrap" : "pre-wrap",
     }
 );
 

--- a/src/views/css/main.ts
+++ b/src/views/css/main.ts
@@ -440,6 +440,7 @@ export const promptWrapper = (status: Status, isSticky: boolean) => {
         styles.width = "100%";
         styles.position = "fixed";
         styles.top = titleBarHeight;
+        styles.height = promptWrapperHeight;
     }
 
     if ([Status.Failure, Status.Interrupted].includes(status)) {

--- a/src/views/css/main.ts
+++ b/src/views/css/main.ts
@@ -531,7 +531,7 @@ export const prompt = Object.assign(
 );
 
 export const promptPlaceholder = {
-    height: promptWrapperHeight,
+    "min-height": promptWrapperHeight,
 };
 
 export const arrowInner = (status: Status) => {


### PR DESCRIPTION
Previously, some elements would overlap if you enter multiple lines in the prompt (via pasting). This fixes that, although it introduces some (less bad, IMO) visual glitches in the sticky top prompt.