### PR TITLE
Load both ~/.bash_history and ~/.black-screen/history

### DIFF
--- a/src/shell/History.ts
+++ b/src/shell/History.ts
@@ -74,7 +74,7 @@ export class History {
         } catch (e) {
             // black screen history file doesn't exist
         }
-        this.storage = flatten(orderBy(histories, "lastModified").map(h => h.commands));
+        this.storage = flatten(orderBy(histories, "lastModified", "desc").map(h => h.commands));
     }
 
     private static remove(entry: string): void {

--- a/src/shell/History.ts
+++ b/src/shell/History.ts
@@ -13,9 +13,9 @@ const readHistoryFileData = () => {
         return {
             lastModified: new Date(0),
             commands: [],
-        }
+        };
     }
-}
+};
 
 export class History {
     static pointer: number = 0;

--- a/src/shell/Session.ts
+++ b/src/shell/Session.ts
@@ -113,7 +113,6 @@ export class Session extends EmitterWithUniqueID {
     };
 
     private deserialize(): void {
-        debugger;
         this.directory = this.readSerialized(presentWorkingDirectoryFilePath, homeDirectory);
         let bashHistoryModifiedTime = new Date(0);
         let bashHistory: string[] = [];

--- a/src/shell/Session.ts
+++ b/src/shell/Session.ts
@@ -118,7 +118,7 @@ export class Session extends EmitterWithUniqueID {
         let bashHistory: string[] = [];
         try {
             bashHistoryModifiedTime = statSync(bashHistoryFilePath).mtime;
-            bashHistory = readFileSync(bashHistoryFilePath).toString().trim().split('\n').reverse();
+            bashHistory = readFileSync(bashHistoryFilePath).toString().trim().split("\n").reverse();
         } catch (error) {
             // File was missing or something. Ignore.
         }
@@ -132,7 +132,7 @@ export class Session extends EmitterWithUniqueID {
             // File was missing or something. Ignore.
         }
 
-        let mergedHistory: string[] = []
+        let mergedHistory: string[] = [];
         if (blackScreenHistoryModifiedTime > bashHistoryModifiedTime) {
             mergedHistory = [...bashHistory, ...blackScreenHistory];
         } else {

--- a/src/shell/Session.ts
+++ b/src/shell/Session.ts
@@ -1,4 +1,4 @@
-import {readFileSync, statSync} from "fs";
+import {readFileSync} from "fs";
 import {Job} from "./Job";
 import {History} from "./History";
 import {EmitterWithUniqueID} from "../EmitterWithUniqueID";
@@ -9,7 +9,6 @@ import {Environment, processEnvironment} from "./Environment";
 import {
     homeDirectory, normalizeDirectory, writeFileCreatingParents,
     presentWorkingDirectoryFilePath, historyFilePath,
-    bashHistoryFilePath,
 } from "../utils/Common";
 import {remote} from "electron";
 import {OrderedSet} from "../utils/OrderedSet";
@@ -114,32 +113,7 @@ export class Session extends EmitterWithUniqueID {
 
     private deserialize(): void {
         this.directory = this.readSerialized(presentWorkingDirectoryFilePath, homeDirectory);
-        let bashHistoryModifiedTime = new Date(0);
-        let bashHistory: string[] = [];
-        try {
-            bashHistoryModifiedTime = statSync(bashHistoryFilePath).mtime;
-            bashHistory = readFileSync(bashHistoryFilePath).toString().trim().split("\n").reverse();
-        } catch (error) {
-            // File was missing or something. Ignore.
-        }
-
-        let blackScreenHistoryModifiedTime = new Date(0);
-        let blackScreenHistory: string[] = [];
-        try {
-            blackScreenHistoryModifiedTime = statSync(historyFilePath).mtime;
-            blackScreenHistory = this.readSerialized(historyFilePath, []);
-        } catch (error) {
-            // File was missing or something. Ignore.
-        }
-
-        let mergedHistory: string[] = [];
-        if (blackScreenHistoryModifiedTime > bashHistoryModifiedTime) {
-            mergedHistory = [...bashHistory, ...blackScreenHistory];
-        } else {
-            mergedHistory = [...blackScreenHistory, ...bashHistory];
-        }
-
-        History.deserialize(mergedHistory);
+        History.deserialize();
     }
 
     private readSerialized<T>(file: string, defaultValue: T): T {

--- a/src/utils/Common.ts
+++ b/src/utils/Common.ts
@@ -342,4 +342,6 @@ export function assign<A extends B, B extends Object>(source: A, assignments: B)
 const baseConfigDirectory = Path.join(homeDirectory, ".black-screen");
 export const presentWorkingDirectoryFilePath = Path.join(baseConfigDirectory, "presentWorkingDirectory");
 export const historyFilePath = Path.join(baseConfigDirectory, "history");
+// We can't use HISTFILE to get the path, so just check the default location
+export const bashHistoryFilePath = Path.join(homeDirectory, ".bash_history");
 export const windowBoundsFilePath = Path.join(baseConfigDirectory, "windowBounds");

--- a/src/utils/Common.ts
+++ b/src/utils/Common.ts
@@ -342,6 +342,4 @@ export function assign<A extends B, B extends Object>(source: A, assignments: B)
 const baseConfigDirectory = Path.join(homeDirectory, ".black-screen");
 export const presentWorkingDirectoryFilePath = Path.join(baseConfigDirectory, "presentWorkingDirectory");
 export const historyFilePath = Path.join(baseConfigDirectory, "history");
-// We can't use HISTFILE to get the path, so just check the default location
-export const bashHistoryFilePath = Path.join(homeDirectory, ".bash_history");
 export const windowBoundsFilePath = Path.join(baseConfigDirectory, "windowBounds");

--- a/src/utils/Shell.ts
+++ b/src/utils/Shell.ts
@@ -41,12 +41,6 @@ class Bash extends Shell {
     }
 
     loadHistory(): { lastModified: Date, commands: string[] } {
-        if (process.env.HISTTIMEFORMAT) {
-            return {
-                lastModified: new Date(0),
-                commands: [],
-            };
-        }
         const path = process.env.HISTFILE || Path.join(homeDirectory, ".bash_history");
         try {
             return {
@@ -109,8 +103,8 @@ const shell = () => {
     }
 };
 
-export function loadAllHistories(): { lastModified: Date, commands: string[] }[] {
-    return values(supportedShells).map((supportedShell: Shell) => supportedShell.loadHistory());
+export function loadHistory(): { lastModified: Date, commands: string[] } {
+    return loginShell.loadHistory();
 }
 
 export const loginShell: Shell = supportedShells[baseName(shell())];

--- a/src/utils/Shell.ts
+++ b/src/utils/Shell.ts
@@ -1,14 +1,8 @@
-<<<<<<< 83e01401fc66ab88e538286f6ab69fb450592643
 import {basename} from "path";
-import {resolveFile, exists, filterAsync} from "./Common";
-=======
 import {readFileSync, statSync} from "fs";
 import * as Path from "path";
 import {EOL} from "os";
-import {baseName, resolveFile, exists, filterAsync, homeDirectory} from "./Common";
-import {values} from "lodash";
-
->>>>>>> Clean up code for loading bash history
+import {resolveFile, exists, filterAsync, homeDirectory} from "./Common";
 
 abstract class Shell {
     abstract get executableName(): string;
@@ -103,8 +97,9 @@ const shell = () => {
     }
 };
 
+export const loginShell: Shell = supportedShells[basename(shell())];
+
 export function loadHistory(): { lastModified: Date, commands: string[] } {
     return loginShell.loadHistory();
 }
 
-export const loginShell: Shell = supportedShells[baseName(shell())];

--- a/src/utils/Shell.ts
+++ b/src/utils/Shell.ts
@@ -1,11 +1,21 @@
+<<<<<<< 83e01401fc66ab88e538286f6ab69fb450592643
 import {basename} from "path";
 import {resolveFile, exists, filterAsync} from "./Common";
+=======
+import {readFileSync, statSync} from "fs";
+import * as Path from "path";
+import {EOL} from "os";
+import {baseName, resolveFile, exists, filterAsync, homeDirectory} from "./Common";
+import {values} from "lodash";
+
+>>>>>>> Clean up code for loading bash history
 
 abstract class Shell {
     abstract get executableName(): string;
     abstract get configFiles(): string[];
     abstract get noConfigSwitches(): string[];
     abstract get preCommandModifiers(): string[];
+    abstract loadHistory(): { lastModified: Date, commands: string[] };
 
     async existingConfigFiles(): Promise<string[]> {
         const resolvedConfigFiles = this.configFiles.map(fileName => resolveFile(process.env.HOME, fileName));
@@ -28,6 +38,27 @@ class Bash extends Shell {
 
     get preCommandModifiers(): string[] {
         return [];
+    }
+
+    loadHistory(): { lastModified: Date, commands: string[] } {
+        if (process.env.HISTTIMEFORMAT) {
+            return {
+                lastModified: new Date(0),
+                commands: [],
+            }
+        }
+        const path = process.env.HISTFILE || Path.join(homeDirectory, ".bash_history");
+        try {
+            return {
+                lastModified: statSync(path).mtime,
+                commands: readFileSync(path).toString().trim().split(EOL).reverse(),
+            }
+        } catch (error) {
+            return {
+                lastModified: new Date(0),
+                commands: [],
+            }
+        }
     }
 }
 
@@ -53,6 +84,14 @@ class ZSH extends Shell {
             "command",
         ];
     }
+
+    loadHistory(): { lastModified: Date, commands: string[] } {
+        // TODO: Read the zsh history as well
+        return {
+            lastModified: new Date(0),
+            commands: [],
+        };
+    }
 }
 
 const supportedShells: Dictionary<Shell> = {
@@ -70,4 +109,8 @@ const shell = () => {
     }
 };
 
-export const loginShell: Shell = supportedShells[basename(shell())];
+export function loadAllHistories(): { lastModified: Date, commands: string[] }[] {
+    return values(supportedShells).map((shell: Shell) => shell.loadHistory());
+}
+
+export const loginShell: Shell = supportedShells[baseName(shell())];

--- a/src/utils/Shell.ts
+++ b/src/utils/Shell.ts
@@ -45,19 +45,19 @@ class Bash extends Shell {
             return {
                 lastModified: new Date(0),
                 commands: [],
-            }
+            };
         }
         const path = process.env.HISTFILE || Path.join(homeDirectory, ".bash_history");
         try {
             return {
                 lastModified: statSync(path).mtime,
                 commands: readFileSync(path).toString().trim().split(EOL).reverse(),
-            }
+            };
         } catch (error) {
             return {
                 lastModified: new Date(0),
                 commands: [],
-            }
+            };
         }
     }
 }
@@ -110,7 +110,7 @@ const shell = () => {
 };
 
 export function loadAllHistories(): { lastModified: Date, commands: string[] }[] {
-    return values(supportedShells).map((shell: Shell) => shell.loadHistory());
+    return values(supportedShells).map((supportedShell: Shell) => supportedShell.loadHistory());
 }
 
 export const loginShell: Shell = supportedShells[baseName(shell())];


### PR DESCRIPTION
Due to some bugs in black-screen I switch between iTerm2 and black-screen. This change reads the command history from both history files, putting the one that was written to most recently first.