### PR TITLE
Clean up code for finding user's shell

### DIFF
--- a/src/utils/Common.ts
+++ b/src/utils/Common.ts
@@ -170,14 +170,6 @@ export function directoryName(path: string): string {
     }
 }
 
-export function baseName(path: string): string {
-    if (path.split(Path.sep).length === 1) {
-        return path;
-    } else {
-        return path.substring(directoryName(path).length);
-    }
-}
-
 export const executablesInPaths = async (path: EnvironmentPath): Promise<string[]> => {
     const validPaths = await filterAsync(path.toArray(), isDirectory);
     const allFiles: string[][] = await Promise.all(validPaths.map(filesIn));

--- a/src/utils/Shell.ts
+++ b/src/utils/Shell.ts
@@ -1,4 +1,5 @@
-import {baseName, resolveFile, exists, filterAsync} from "./Common";
+import {basename} from "path";
+import {resolveFile, exists, filterAsync} from "./Common";
 
 abstract class Shell {
     abstract get executableName(): string;
@@ -59,23 +60,14 @@ const supportedShells: Dictionary<Shell> = {
     zsh: new ZSH() ,
 };
 
-const {shell} = new class {
-    /* tslint:disable:member-ordering */
-    private shellPath: string;
-
-    shell = () => {
-        if (!this.shellPath) {
-            const shellName = baseName(process.env.SHELL);
-            if (shellName in supportedShells) {
-                this.shellPath = process.env.SHELL;
-            } else {
-                this.shellPath = "/bin/bash";
-                console.error(`${shellName} is not supported; defaulting to ${this.shellPath}`);
-            }
-        }
-
-        return this.shellPath;
-    };
+const shell = () => {
+    const shellName = basename(process.env.SHELL);
+    if (shellName in supportedShells) {
+        return process.env.SHELL;
+    } else {
+        console.error(`${shellName} is not supported; defaulting to /bin/bash`);
+        return "/bin/bash";
+    }
 };
 
-export const loginShell: Shell = supportedShells[baseName(shell())];
+export const loginShell: Shell = supportedShells[basename(shell())];


### PR DESCRIPTION
I noticed the shell() function was memoizing, which seems unnecessary since it's not an expensive operation and is only ever called once anyway. I also removed `baseName`, which seems to be a re-implementation of built in function `basename`.