### PR TITLE
Removed ligatures from prompt

### DIFF
--- a/src/views/css/definitions.ts
+++ b/src/views/css/definitions.ts
@@ -51,7 +51,6 @@ export interface CSSObject {
     textDecoration?: "underline";
     fontWeight?: "bold";
     fontSize?: number;
-    WebkitFontFeatureSettings?: '"liga", "dlig"';
     WebkitAppearance?: "none";
 }
 

--- a/src/views/css/main.ts
+++ b/src/views/css/main.ts
@@ -98,7 +98,6 @@ const promptInlineElement: CSSObject = {
     paddingLeft: promptHorizontalPadding,
     gridArea: promptGrid.prompt.name,
     fontSize: fontSize,
-    WebkitFontFeatureSettings: '"liga", "dlig"',
     whiteSpace: "pre-wrap",
     WebkitAppearance: "none",
     outline: "none",


### PR DESCRIPTION
This fixes #615.

Another option would be to relax the type definition for that field to allow only some ligatures to be disabled.