### PR TITLE
Strip bash funcs

### DIFF
--- a/src/PTY.ts
+++ b/src/PTY.ts
@@ -23,9 +23,7 @@ export class PTY {
             env: env,
         });
 
-        this.terminal.on("data", (data: string) => {
-            dataHandler(data)
-        });
+        this.terminal.on("data", (data: string) => dataHandler(data));
         this.terminal.on("exit", (code: number) => {
             exitHandler(code);
         });

--- a/src/PTY.ts
+++ b/src/PTY.ts
@@ -23,7 +23,9 @@ export class PTY {
             env: env,
         });
 
-        this.terminal.on("data", (data: string) => dataHandler(data));
+        this.terminal.on("data", (data: string) => {
+            dataHandler(data)
+        });
         this.terminal.on("exit", (code: number) => {
             exitHandler(code);
         });

--- a/src/shell/Environment.ts
+++ b/src/shell/Environment.ts
@@ -8,6 +8,17 @@ import {AbstractOrderedSet} from "../utils/OrderedSet";
 const ignoredEnvironmentVariables = [
     "NODE_ENV",
 ];
+
+const isIgnoredEnvironmentVariable = (varName: string) => {
+    if (ignoredEnvironmentVariables.includes(varName)) {
+        return true;
+    } else if (/^BASH_FUNC\w+%%$/.test(varName)) {
+        return true;
+    } else {
+        return false;
+    }
+};
+
 export const processEnvironment: Dictionary<string> = {};
 export async function loadEnvironment(): Promise<void> {
     const lines = await executeCommandWithShellConfig("env");
@@ -16,8 +27,8 @@ export async function loadEnvironment(): Promise<void> {
         let [key, value] = line.trim().split("=");
 
         // Strip bash functions from environment, as they cause issues.
-        // TODO: put the code for stripping bash functions in a better place.
-        if (!ignoredEnvironmentVariables.includes(key) && !/^BASH_FUNC\w+%%$/.test(key)) {
+        // TODO: actually support bash functions
+        if (!isIgnoredEnvironmentVariable(key)) {
             processEnvironment[key] = value;
         }
     });

--- a/src/shell/Environment.ts
+++ b/src/shell/Environment.ts
@@ -15,7 +15,9 @@ export async function loadEnvironment(): Promise<void> {
     lines.forEach(line => {
         let [key, value] = line.trim().split("=");
 
-        if (!ignoredEnvironmentVariables.includes(key)) {
+        // Strip bash functions from environment, as they cause issues.
+        // TODO: put the code for stripping bash functions in a better place.
+        if (!ignoredEnvironmentVariables.includes(key) && !/^BASH_FUNC\w+%%$/.test(key)) {
             processEnvironment[key] = value;
         }
     });


### PR DESCRIPTION
The removes all `BASH_FUNC_foo%%` env vars at load time, as those cause issues when actually running bash commands. I couldn't find a better place to put this, if you have a suggestion I'd be happy to move it there.