### PR TITLE
Fix pasting when prompt already contains text

### DIFF
--- a/src/views/4_PromptComponent.tsx
+++ b/src/views/4_PromptComponent.tsx
@@ -57,12 +57,9 @@ export class PromptComponent extends React.Component<Props, State> {
 
         if (this.props.status === e.Status.InProgress) {
             this.props.job.write(text);
-        } else {
-            this.setText(text);
+            event.stopPropagation();
+            event.preventDefault();
         }
-
-        event.stopPropagation();
-        event.preventDefault();
     };
 
     /* tslint:disable:member-ordering */


### PR DESCRIPTION
Fix by allowing the event to continue propagating when job is not in progress.

Fixes #635 