### PR TITLE
Add commands from history to autocomplete

### DIFF
--- a/src/Autocompletion.ts
+++ b/src/Autocompletion.ts
@@ -1,10 +1,19 @@
 import {Job} from "./shell/Job";
 import {leafNodeAt} from "./shell/Parser";
 import * as _ from "lodash";
+import {History} from "./shell/History";
+import {Suggestion, styles} from "./plugins/autocompletion_providers/Common";
 
 export const suggestionsLimit = 9;
 
 export const getSuggestions = async(job: Job, caretPosition: number) => {
+    const prefixMatchesInHistory = History.all.filter(line => line.startsWith(job.prompt.value));
+    const suggestionsFromHistory = prefixMatchesInHistory.map(match => new Suggestion({
+        value: match,
+        shouldEscapeSpaces: false,
+        style: styles.command,
+    }));
+
     const node = leafNodeAt(caretPosition, job.prompt.ast);
     const suggestions = await node.suggestions({
         environment: job.environment,
@@ -12,7 +21,7 @@ export const getSuggestions = async(job: Job, caretPosition: number) => {
         aliases: job.session.aliases,
     });
 
-    const applicableSuggestions = _.uniqBy(suggestions, suggestion => suggestion.value).filter(suggestion =>
+    const applicableSuggestions = _.uniqBy([...suggestionsFromHistory, ...suggestions], suggestion => suggestion.value).filter(suggestion =>
         suggestion.value.toLowerCase().startsWith(node.value.toLowerCase())
     );
 

--- a/src/Autocompletion.ts
+++ b/src/Autocompletion.ts
@@ -11,8 +11,11 @@ export const getSuggestions = async(job: Job, caretPosition: number) => {
     const suggestionsFromHistory = prefixMatchesInHistory.map(match => new Suggestion({
         value: match,
         shouldEscapeSpaces: false,
-        style: styles.command,
+        style: styles.history,
     }));
+
+    const firstThreeFromHistory = suggestionsFromHistory.slice(0, 3);
+    const remainderFromHistory = suggestionsFromHistory.slice(3);
 
     const node = leafNodeAt(caretPosition, job.prompt.ast);
     const suggestions = await node.suggestions({
@@ -21,7 +24,7 @@ export const getSuggestions = async(job: Job, caretPosition: number) => {
         aliases: job.session.aliases,
     });
 
-    const applicableSuggestions = _.uniqBy([...suggestionsFromHistory, ...suggestions], suggestion => suggestion.value).filter(suggestion =>
+    const applicableSuggestions = _.uniqBy([...firstThreeFromHistory, ...suggestions, ...remainderFromHistory], suggestion => suggestion.value).filter(suggestion =>
         suggestion.value.toLowerCase().startsWith(node.value.toLowerCase())
     );
 

--- a/src/plugins/autocompletion_providers/Common.ts
+++ b/src/plugins/autocompletion_providers/Common.ts
@@ -19,6 +19,7 @@ interface SuggestionAttributes {
     description?: string;
     style?: Style;
     space?: boolean;
+    shouldEscapeSpaces?: boolean;
 }
 
 export class Suggestion {
@@ -46,8 +47,18 @@ export class Suggestion {
         return this.attributes.displayValue || this.value;
     }
 
+    valueForPrompt(): string {
+        const escaped = this.shouldEscapeSpaces ? this.value.replace(/\s/g, "\\ ") : this.value;
+        const spaceAdded = this.shouldAddSpace ? escaped + " " : escaped;
+        return spaceAdded;
+    }
+
     get shouldAddSpace(): boolean {
         return this.attributes.space || false;
+    }
+
+    get shouldEscapeSpaces(): boolean {
+        return !!this.attributes.shouldEscapeSpaces;
     }
 
     withValue(value: string): this {

--- a/src/plugins/autocompletion_providers/Common.ts
+++ b/src/plugins/autocompletion_providers/Common.ts
@@ -174,6 +174,12 @@ export const styles = {
             fontStyle: "italic",
         },
     },
+    history: {
+        value: fontAwesome.history,
+        css: {
+            color: colors.blue,
+        },
+    },
 };
 
 export const unique = (provider: AutocompletionProvider): AutocompletionProvider => mk(async (context) => {

--- a/src/views/4_PromptComponent.tsx
+++ b/src/views/4_PromptComponent.tsx
@@ -273,8 +273,7 @@ export class PromptComponent extends React.Component<Props, State> {
         const ast = this.props.job.prompt.ast;
         const suggestion = this.state.suggestions[this.state.highlightedSuggestionIndex];
         const node = leafNodeAt(getCaretPosition(this.commandNode), ast);
-
-        return serializeReplacing(ast, node, suggestion.value.replace(/\s/g, "\\ ") + (suggestion.shouldAddSpace ? " " : ""));
+        return serializeReplacing(ast, node, suggestion.valueForPrompt());
     }
 
     private showAutocomplete(): boolean {


### PR DESCRIPTION
Show commands run in the past as autocomplete suggestions if their prefix matches what you've already typed.

![image](https://cloud.githubusercontent.com/assets/558242/17090486/d0932b4c-51e5-11e6-9087-9c0c36478e1e.png)

![image](https://cloud.githubusercontent.com/assets/558242/17090533/3595c202-51e6-11e6-9ba6-a5097f9ce52e.png)

![image](https://cloud.githubusercontent.com/assets/558242/17090556/529becd2-51e6-11e6-8fdc-619ce464dca3.png)
