### PR TITLE
Add ability to parse man pages with line breaks in a flag description, and cp autocomplete

### DIFF
--- a/src/plugins/autocompletion_providers/Cp.ts
+++ b/src/plugins/autocompletion_providers/Cp.ts
@@ -1,0 +1,6 @@
+import {PluginManager} from "../../PluginManager";
+import {anyFilesSuggestionsProvider} from "../autocompletion_utils/Common";
+import combine from "../autocompletion_utils/Combine";
+import {manPageOptions} from "../../utils/ManPages";
+
+PluginManager.registerAutocompletionProvider("cp", combine([anyFilesSuggestionsProvider, manPageOptions("cp")]));

--- a/src/utils/ManPageParsingUtils.ts
+++ b/src/utils/ManPageParsingUtils.ts
@@ -37,7 +37,21 @@ export const extractManPageSections = (contents: string) => {
 };
 
 export const extractManPageSectionParagraphs = (contents: string[]) => {
-    return contents
+    const filteredContents = contents.filter((line, index, array) => {
+        if (index === 0 || index === array.length - 1) {
+            return true;
+        }
+        if (
+            line === "" &&
+            array[index - 1].startsWith("           ") &&
+            array[index + 1].startsWith("           ")
+        ) {
+            return false;
+        }
+        return true;
+    });
+
+    return filteredContents
     .reduce(
         (memo, next) => {
             if (next === "") {

--- a/src/utils/ManPages.ts
+++ b/src/utils/ManPages.ts
@@ -10,8 +10,10 @@ import {
 // Note: this is still pretty experimental. If you want to do man page parsing
 // for a new command, expect to have to make some changes here.
 
-// TODO: Handle option descriptions that have empty lines. Unblocks:
-// -p and -R in cp
+// TODO: Handle option descriptions that have empty lines,
+// when the spacing for flag descriptions isn't exactly 11
+// characters
+// Unblocks:
 // df
 // locate
 // TODO: Handle nested options. Unblocks:

--- a/test/utils/ManPages_spec.ts
+++ b/test/utils/ManPages_spec.ts
@@ -71,6 +71,24 @@ describe("man page paragraph extraction", () => {
       ["p2", "p2"],
     ]);
   });
+
+  it("can handle flag descriptions that have blank lines in the middle", () => {
+    expect(extractManPageSectionParagraphs([
+      "     -f1   line one",
+      "           line two",
+      "",
+      "           line three",
+      "",
+      "     -f2   line one",
+    ])).to.eql([
+      [
+        "     -f1   line one",
+        "           line two",
+        "           line three",
+      ],
+      ["     -f2   line one"]
+    ]);
+  });
 });
 
 describe("suggestion parser", () => {
@@ -99,8 +117,7 @@ describe("suggestion parser", () => {
     }));
   });
 
-  // Happens if the description of a flag is spilt across multiples lines.
-  // TODO: actually parse those flags and use them in autocomplete
+  // DESCRIPTION section can contain things other than flags
   it("returns undefined if attempting to parse paragraph with no flag", () => {
     expect(suggestionFromFlagParagraph([
       "        no flag",


### PR DESCRIPTION
After this one I will make a PR that auto-detects the number of spaces in a line that is part of the same paragraph.