### PR TITLE
Added Keybinding support & Menu support for Linux/Windows

### DIFF
--- a/src/Enums.ts
+++ b/src/Enums.ts
@@ -97,3 +97,47 @@ export enum SplitDirection {
     Vertical,
     Horizontal,
 }
+
+export enum KeyboardAction {
+    // CLI commands
+    cliRunCommand,
+    cliInterrupt,
+    cliClearJobs,
+    cliDeleteWord,
+    cliClearText,
+    cliAppendLastArgumentOfPreviousCommand,
+    cliHistoryPrevious,
+    cliHistoryNext,
+    // autocomplete commands
+    autocompleteInsertCompletion,
+    autocompletePreviousSuggestion,
+    autocompleteNextSuggestion,
+    // tab commands
+    tabNew,
+    tabFocus,
+    tabPrevious,
+    tabNext,
+    tabClose,
+    // edit/clipboard commands
+    clipboardCopy,
+    clipboardCut,
+    clipboardPaste,
+    editUndo,
+    editRedo,
+    editSelectAll,
+    editFind,
+    editFindClose,
+    // window commands
+    windowSplitHorizontally,
+    windowSplitVertically,
+    // view commands
+    viewReload,
+    viewToggleFullScreen,
+    // black screen commands
+    blackScreenHide,
+    blackScreenQuit,
+    blackScreenHideOthers,
+    // developer
+    developerToggleTools,
+    developerToggleDebugMode,
+}

--- a/src/views/UserEventsHander.ts
+++ b/src/views/UserEventsHander.ts
@@ -3,188 +3,201 @@ import {SessionComponent} from "./2_SessionComponent";
 import {PromptComponent} from "./4_PromptComponent";
 import {JobComponent} from "./3_JobComponent";
 import {Tab} from "./TabComponent";
-import {KeyCode, SplitDirection, Status} from "../Enums";
+import {Status, KeyboardAction} from "../Enums";
 import {isModifierKey} from "./ViewUtils";
 import {SearchComponent} from "./SearchComponent";
 import {remote} from "electron";
+import {buildMenuTemplate} from "./menu/Menu";
+import {isKeybidingForEvent} from "./keyevents/Keybindings";
 
 export type UserEvent = KeyboardEvent | ClipboardEvent;
 
 export const handleUserEvent = (application: ApplicationComponent,
-                                tab: Tab,
-                                session: SessionComponent,
-                                job: JobComponent,
-                                prompt: PromptComponent,
-                                search: SearchComponent) => (event: UserEvent) => {
-    if (event instanceof ClipboardEvent) {
+    tab: Tab,
+    session: SessionComponent,
+    job: JobComponent,
+    prompt: PromptComponent,
+    search: SearchComponent) => (event: UserEvent) => {
+        if (event instanceof ClipboardEvent) {
+            if (search.isFocused) {
+                return;
+            }
+
+            if (!isInProgress(job)) {
+                prompt.focus();
+                return;
+            }
+
+            job.props.job.write(event.clipboardData.getData("text/plain"));
+
+            event.stopPropagation();
+            event.preventDefault();
+
+            return;
+        }
+
+        // Close focused pane
+        if (isKeybidingForEvent(event, KeyboardAction.tabClose) && !isInProgress(job)) {
+            application.closeFocusedPane();
+
+            application.forceUpdate();
+
+            event.stopPropagation();
+            event.preventDefault();
+            return;
+        }
+
+        // Change tab action
+        if (isKeybidingForEvent(event, KeyboardAction.tabFocus)) {
+            const position = parseInt(event.key, 10);
+            application.focusTab(position);
+
+            event.stopPropagation();
+            event.preventDefault();
+            return;
+        }
+
+        // Enable debug mode
+        if (isKeybidingForEvent(event, KeyboardAction.developerToggleDebugMode)) {
+            window.DEBUG = !window.DEBUG;
+
+            require("devtron").install();
+            console.log(`Debugging mode has been ${window.DEBUG ? "enabled" : "disabled"}.`);
+
+            application.forceUpdate();
+
+            event.stopPropagation();
+            event.preventDefault();
+            return;
+        }
+
+        // Console clear
+        if (isKeybidingForEvent(event, KeyboardAction.cliClearJobs) && !isInProgress(job)) {
+            session.props.session.clearJobs();
+
+            event.stopPropagation();
+            event.preventDefault();
+            return;
+        }
+
+        if (event.metaKey) {
+            event.stopPropagation();
+            // Don't prevent default to be able to open developer tools and such.
+            return;
+        }
+
         if (search.isFocused) {
+            // Search close
+            if (isKeybidingForEvent(event, KeyboardAction.editFindClose)) {
+                search.clearSelection();
+                setTimeout(() => prompt.focus(), 0);
+
+                event.stopPropagation();
+                event.preventDefault();
+                return;
+            }
+
+            return;
+        }
+
+
+        if (isInProgress(job) && !isModifierKey(event)) {
+            // CLI interrupt
+            if (isKeybidingForEvent(event, KeyboardAction.cliInterrupt)) {
+                job.props.job.interrupt();
+            } else {
+                job.props.job.write(event);
+            }
+
+            event.stopPropagation();
+            event.preventDefault();
+            return;
+        }
+
+        prompt.focus();
+
+        // Append last argument to prompt
+        if (isKeybidingForEvent(event, KeyboardAction.cliAppendLastArgumentOfPreviousCommand)) {
+            prompt.appendLastLArgumentOfPreviousCommand();
+
+            event.stopPropagation();
+            event.preventDefault();
             return;
         }
 
         if (!isInProgress(job)) {
-            prompt.focus();
-            return;
-        }
-
-        job.props.job.write(event.clipboardData.getData("text/plain"));
-
-        event.stopPropagation();
-        event.preventDefault();
-
-        return;
-    }
-
-    if (event.ctrlKey && event.keyCode === KeyCode.D && !isInProgress(job)) {
-        application.closeFocusedPane();
-
-        application.forceUpdate();
-
-        event.stopPropagation();
-        event.preventDefault();
-        return;
-    }
-
-    if (event.metaKey && event.keyCode >= KeyCode.One && event.keyCode <= KeyCode.Nine) {
-        const position = parseInt(event.key, 10);
-        application.focusTab(position);
-
-        event.stopPropagation();
-        event.preventDefault();
-        return;
-    }
-
-    if (event.metaKey && event.keyCode === KeyCode.D) {
-        window.DEBUG = !window.DEBUG;
-
-        require("devtron").install();
-        console.log(`Debugging mode has been ${window.DEBUG ? "enabled" : "disabled"}.`);
-
-        application.forceUpdate();
-
-        event.stopPropagation();
-        event.preventDefault();
-        return;
-    }
-
-    if (event.ctrlKey && event.keyCode === KeyCode.L && !isInProgress(job)) {
-        session.props.session.clearJobs();
-
-        event.stopPropagation();
-        event.preventDefault();
-        return;
-    }
-
-    if (event.metaKey) {
-        event.stopPropagation();
-        // Don't prevent default to be able to open developer tools and such.
-        return;
-    }
-
-    if (search.isFocused) {
-        if (event.keyCode === KeyCode.Escape) {
-            search.clearSelection();
-            setTimeout(() => prompt.focus(), 0);
-
-            event.stopPropagation();
-            event.preventDefault();
-            return;
-        }
-
-        return;
-    }
-
-    if (isInProgress(job) && !isModifierKey(event)) {
-        if (event.ctrlKey && event.keyCode === KeyCode.C) {
-            job.props.job.interrupt();
-        } else {
-            job.props.job.write(event);
-        }
-
-        event.stopPropagation();
-        event.preventDefault();
-        return;
-    }
-
-    prompt.focus();
-
-    if (event.keyCode === KeyCode.Period && event.altKey) {
-        prompt.appendLastLArgumentOfPreviousCommand();
-
-        event.stopPropagation();
-        event.preventDefault();
-        return;
-    }
-
-    if (!isInProgress(job)) {
-        if (event.ctrlKey && event.keyCode === KeyCode.W) {
-            prompt.deleteWord();
-
-            event.stopPropagation();
-            event.preventDefault();
-            return;
-        }
-
-        if (event.keyCode === KeyCode.CarriageReturn) {
-            prompt.execute((event.target as HTMLElement).innerText);
-
-            event.stopPropagation();
-            event.preventDefault();
-            return;
-        }
-
-        if (event.ctrlKey && event.keyCode === KeyCode.C) {
-            prompt.clear();
-
-            event.stopPropagation();
-            event.preventDefault();
-            return;
-        }
-
-        if (prompt.isAutocompleteShown()) {
-            if (event.keyCode === KeyCode.Tab) {
-                prompt.applySuggestion();
+            // CLI Delete word
+            if (isKeybidingForEvent(event, KeyboardAction.cliDeleteWord)) {
+                prompt.deleteWord();
 
                 event.stopPropagation();
                 event.preventDefault();
                 return;
             }
 
-            if ((event.ctrlKey && event.keyCode === KeyCode.P) || event.keyCode === KeyCode.Up) {
-                prompt.focusPreviousSuggestion();
+            // CLI execute command
+            if (isKeybidingForEvent(event, KeyboardAction.cliRunCommand)) {
+                prompt.execute((event.target as HTMLElement).innerText);
 
                 event.stopPropagation();
                 event.preventDefault();
                 return;
             }
 
-            if ((event.ctrlKey && event.keyCode === KeyCode.N) || event.keyCode === KeyCode.Down) {
-                prompt.focusNextSuggestion();
-
-                event.stopPropagation();
-                event.preventDefault();
-                return;
-            }
-        } else {
-            if ((event.ctrlKey && event.keyCode === KeyCode.P) || event.keyCode === KeyCode.Up) {
-                prompt.setPreviousHistoryItem();
+            // CLI clear
+            if (isKeybidingForEvent(event, KeyboardAction.cliClearText)) {
+                prompt.clear();
 
                 event.stopPropagation();
                 event.preventDefault();
                 return;
             }
 
-            if ((event.ctrlKey && event.keyCode === KeyCode.N) || event.keyCode === KeyCode.Down) {
-                prompt.setNextHistoryItem();
+            if (prompt.isAutocompleteShown()) {
+                if (isKeybidingForEvent(event, KeyboardAction.autocompleteInsertCompletion)) {
+                    prompt.applySuggestion();
 
-                event.stopPropagation();
-                event.preventDefault();
-                return;
+                    event.stopPropagation();
+                    event.preventDefault();
+                    return;
+                }
+
+                if (isKeybidingForEvent(event, KeyboardAction.autocompletePreviousSuggestion)) {
+                    prompt.focusPreviousSuggestion();
+
+                    event.stopPropagation();
+                    event.preventDefault();
+                    return;
+                }
+
+                if (isKeybidingForEvent(event, KeyboardAction.autocompleteNextSuggestion)) {
+                    prompt.focusNextSuggestion();
+
+                    event.stopPropagation();
+                    event.preventDefault();
+                    return;
+                }
+            } else {
+                if (isKeybidingForEvent(event, KeyboardAction.cliHistoryPrevious)) {
+                    prompt.setPreviousHistoryItem();
+
+                    event.stopPropagation();
+                    event.preventDefault();
+                    return;
+                }
+
+                if (isKeybidingForEvent(event, KeyboardAction.cliHistoryNext)) {
+                    prompt.setNextHistoryItem();
+
+                    event.stopPropagation();
+                    event.preventDefault();
+                    return;
+                }
             }
         }
-    }
 
-    prompt.setPreviousKeyCode(event);
-};
+        prompt.setPreviousKeyCode(event);
+    };
 
 function isInProgress(job: JobComponent): boolean {
     return job.props.job.status === Status.InProgress;
@@ -192,184 +205,6 @@ function isInProgress(job: JobComponent): boolean {
 
 const app = remote.app;
 const browserWindow = remote.BrowserWindow.getAllWindows()[0];
+const template = buildMenuTemplate(app, browserWindow);
 
-if (process.platform === "darwin") {
-    const template: Electron.MenuItemOptions[] = [
-        {
-            label: "Black Screen",
-            submenu: [
-                {
-                    label: "About Black Screen",
-                    role: "about",
-                },
-                {
-                    type: "separator",
-                },
-                {
-                    label: "Hide Black Screen",
-                    accelerator: "Command+H",
-                    click: () => {
-                        app.hide();
-                    },
-                },
-                {
-                    label: "Hide Others",
-                    accelerator: "Alt+Command+H",
-                    role: "hideothers",
-                },
-                {
-                    type: "separator",
-                },
-                {
-                    label: "Quit",
-                    accelerator: "Command+Q",
-                    click: () => {
-                        app.quit();
-                    },
-                },
-            ],
-        },
-        {
-            label: "Edit",
-            submenu: [
-                {
-                    label: "Undo",
-                    accelerator: "Command+Z",
-                    role: "undo",
-                },
-                {
-                    label: "Redo",
-                    accelerator: "Shift+Command+Z",
-                    role: "redo",
-                },
-                {
-                    label: "Find",
-                    accelerator: "Command+F",
-                    click: () => {
-                        (document.querySelector("input[type=search]") as HTMLInputElement).select();
-                    },
-                },
-                {
-                    type: "separator",
-                },
-                {
-                    label: "Cut",
-                    accelerator: "Command+X",
-                    role: "cut",
-                },
-                {
-                    label: "Copy",
-                    accelerator: "Command+C",
-                    role: "copy",
-                },
-                {
-                    label: "Paste",
-                    accelerator: "Command+V",
-                    role: "paste",
-                },
-                {
-                    label: "Select All",
-                    accelerator: "Command+A",
-                    role: "selectall",
-                },
-            ],
-        },
-        {
-            label: "View",
-            submenu: [
-                {
-                    label: "Reload",
-                    accelerator: "Command+R",
-                    click: () => {
-                        browserWindow.reload();
-                    },
-                },
-                {
-                    label: "Toggle Full Screen",
-                    accelerator: "Ctrl+Command+F",
-                    click: () => {
-                        browserWindow.setFullScreen(!browserWindow.isFullScreen());
-                    },
-                },
-                {
-                    label: "Toggle Developer Tools",
-                    accelerator: "Alt+Command+I",
-                    click: () => {
-                        browserWindow.webContents.toggleDevTools();
-                    },
-                },
-            ],
-        },
-        {
-            label: "Window",
-            submenu: [
-                {
-                    label: "Add Tab",
-                    accelerator: "Command+t",
-                    click: () => {
-                        window.application.addTab();
-                    },
-                },
-                {
-                    label: "Split Horizontally",
-                    accelerator: "Command+-",
-                    click: () => {
-                        window.focusedTab.addPane(SplitDirection.Horizontal);
-                        window.application.forceUpdate();
-                    },
-                },
-                {
-                    label: "Split Vertically",
-                    accelerator: "Command+\\",
-                    click: () => {
-                        window.focusedTab.addPane(SplitDirection.Vertical);
-                        window.application.forceUpdate();
-                    },
-                },
-            ],
-        },
-        {
-            label: "Pane",
-            submenu: [
-                {
-                    label: "Previous",
-                    accelerator: "Command+k",
-                    click: () => {
-                        window.focusedTab.activatePreviousPane();
-                        window.application.forceUpdate();
-                    },
-                },
-                {
-                    label: "Next",
-                    accelerator: "Command+j",
-                    click: () => {
-                        window.focusedTab.activateNextPane();
-                        window.application.forceUpdate();
-                    },
-                },
-                {
-                    label: "Close",
-                    accelerator: "Command+w",
-                    click: () => {
-                        window.application.closeFocusedPane();
-                        window.application.forceUpdate();
-                    },
-                },
-            ],
-        },
-        {
-            label: "Help",
-            submenu: [
-                {
-                    label: "GitHub Repository",
-                    click: () => {
-                        /* tslint:disable:no-unused-expression */
-                        remote.shell.openExternal("https://github.com/shockone/black-screen");
-                    },
-                },
-            ],
-        },
-    ];
-
-    remote.Menu.setApplicationMenu(remote.Menu.buildFromTemplate(template));
-}
+remote.Menu.setApplicationMenu(remote.Menu.buildFromTemplate(template));

--- a/src/views/keyevents/Keybindings.ts
+++ b/src/views/keyevents/Keybindings.ts
@@ -1,0 +1,222 @@
+import {KeyCode, KeyboardAction} from "../../Enums";
+import {error} from "../../utils/Common";
+
+export type KeybindingType = {
+    action: KeyboardAction,
+    keybinding: (e: KeyboardEvent) => boolean,
+};
+
+function isMeta(e: KeyboardEvent): boolean {
+    /**
+     * Decides if a keyboard event contains the meta key for all platforms
+     * Linux does not support the metaKey so it can be manually changed here
+     * Windows/OSX is simply e.metaKey
+     */
+    if (e.metaKey) {
+        return true;
+    } else if (process.platform === "linux") {
+        return e.ctrlKey;
+    }
+    return false;
+}
+
+export const KeybindingsForActions: KeybindingType[] = [
+    // CLI commands
+    {
+        action: KeyboardAction.cliRunCommand,
+        keybinding: (e: KeyboardEvent) => e.keyCode === KeyCode.CarriageReturn,
+    },
+    {
+        action: KeyboardAction.cliInterrupt,
+        keybinding: (e: KeyboardEvent) => e.ctrlKey && e.keyCode === KeyCode.C,
+    },
+    {
+        action: KeyboardAction.cliClearJobs,
+        keybinding: (e: KeyboardEvent) => e.ctrlKey && e.keyCode === KeyCode.L,
+    },
+    {
+        action: KeyboardAction.cliDeleteWord,
+        keybinding: (e: KeyboardEvent) => e.ctrlKey && e.keyCode === KeyCode.W,
+    },
+    {
+        action: KeyboardAction.cliClearText,
+        // Need to include !shiftKey otherwise it will clear instead of copying
+        keybinding: (e: KeyboardEvent) => e.ctrlKey && e.keyCode === KeyCode.C && !e.shiftKey,
+    },
+    {
+        action: KeyboardAction.cliAppendLastArgumentOfPreviousCommand,
+        keybinding: (e: KeyboardEvent) => e.altKey && e.keyCode === KeyCode.Period,
+    },
+    {
+        action: KeyboardAction.cliHistoryPrevious,
+        keybinding: (e: KeyboardEvent) => {
+            return (e.ctrlKey && e.keyCode === KeyCode.P) || (e.keyCode === KeyCode.Up);
+        },
+    },
+    {
+        action: KeyboardAction.cliHistoryNext,
+        keybinding: (e: KeyboardEvent) => {
+            return (e.ctrlKey && e.keyCode === KeyCode.N) || (e.keyCode === KeyCode.Down);
+        },
+    },
+    // autocomplete commands
+    {
+        action: KeyboardAction.autocompleteInsertCompletion,
+        keybinding: (e: KeyboardEvent) => e.keyCode === KeyCode.Tab,
+    },
+    {
+        action: KeyboardAction.autocompletePreviousSuggestion,
+        keybinding: (e: KeyboardEvent) => {
+            return (e.ctrlKey && e.keyCode === KeyCode.P) || (e.keyCode === KeyCode.Up);
+        },
+    },
+    {
+        action: KeyboardAction.autocompleteNextSuggestion,
+        keybinding: (e: KeyboardEvent) => {
+            return (e.ctrlKey && e.keyCode === KeyCode.N) || (e.keyCode === KeyCode.Down);
+        },
+    },
+    // tab commands
+    {
+        action: KeyboardAction.tabClose,
+        keybinding: (e: KeyboardEvent) => isMeta(e) && e.keyCode === KeyCode.D,
+    },
+    {
+        action: KeyboardAction.tabFocus,
+        keybinding: (e: KeyboardEvent) => {
+            return (e.ctrlKey && e.keyCode >= KeyCode.One && e.keyCode <= KeyCode.Nine);
+        },
+    },
+    // search commands
+    {
+        action: KeyboardAction.editFindClose,
+        keybinding: (e: KeyboardEvent) => e.keyCode === KeyCode.Escape,
+    },
+];
+
+export function isKeybidingForEvent(event: KeyboardEvent, action: KeyboardAction): boolean {
+    /**
+     * Finds the keybinding for the given action and returns the result of the keybinding function
+     */
+    let matchingKeyboardAction = KeybindingsForActions.filter((keybinding) => {
+        return keybinding.action === action;
+    });
+    if (matchingKeyboardAction.length === 0) {
+        error("No matching keybinding for action: " + KeyboardAction[action]);
+        return false;
+    }
+    return matchingKeyboardAction[0].keybinding(event);
+}
+
+// Menu Stuff
+export type KeybindingMenuType = {
+    action: KeyboardAction,
+    accelerator: string,
+};
+
+const CopyAccelerator = process.platform === "darwin" ? "Command+C" : "Ctrl+Shift+C";
+const ToggleFullScreenAccelerator = process.platform === "darwin" ? "Command+F" : "Ctrl+Shift+F";
+
+export const KeybindingsForMenu: KeybindingMenuType[] = [
+    {
+        action: KeyboardAction.tabNew,
+        accelerator: "CmdOrCtrl+T",
+    },
+    {
+        action: KeyboardAction.tabPrevious,
+        accelerator: "CmdOrCtrl+K",
+    },
+    {
+        action: KeyboardAction.tabNext,
+        accelerator: "CmdOrCtrl+J",
+    },
+    {
+        action: KeyboardAction.tabClose,
+        accelerator: "CmdOrCtrl+W",
+    },
+    // edit/clipboard commands
+    {
+        action: KeyboardAction.clipboardCopy,
+        accelerator: CopyAccelerator,
+    },
+    {
+        action: KeyboardAction.clipboardCut,
+        accelerator: "CmdOrCtrl+X",
+    },
+    {
+        action: KeyboardAction.clipboardPaste,
+        accelerator: "CmdOrCtrl+V",
+    },
+    {
+        action: KeyboardAction.editUndo,
+        accelerator: "CmdOrCtrl+Z",
+    },
+    {
+        action: KeyboardAction.editRedo,
+        accelerator: "CmdOrCtrl+Shift+Z",
+    },
+    {
+        action: KeyboardAction.editSelectAll,
+        accelerator: "CmdOrCtrl+A",
+    },
+    {
+        action: KeyboardAction.editFind,
+        accelerator: "CmdOrCtrl+F",
+    },
+    {
+        action: KeyboardAction.editFindClose,
+        accelerator: "Esc",
+    },
+    // window commands
+    {
+        action: KeyboardAction.windowSplitHorizontally,
+        accelerator: "CmdOrCtrl+-",
+    },
+    {
+        action: KeyboardAction.windowSplitVertically,
+        accelerator: "CmdOrCtrl+\\",
+    },
+    // view commands
+    {
+        action: KeyboardAction.viewReload,
+        accelerator: "CmdOrCtrl+R",
+    },
+    {
+        action: KeyboardAction.viewToggleFullScreen,
+        accelerator: ToggleFullScreenAccelerator,
+    },
+    // black screen commands
+    {
+        action: KeyboardAction.blackScreenHide,
+        accelerator: "CmdOrCtrl+H",
+    },
+    {
+        action: KeyboardAction.blackScreenQuit,
+        accelerator: "CmdOrCtrl+Q",
+    },
+    {
+        action: KeyboardAction.blackScreenHideOthers,
+        accelerator: "CmdOrCtrl+Alt+H",
+    },
+    // developer
+    {
+        action: KeyboardAction.developerToggleTools,
+        accelerator: "CmdOrCtrl+Alt+I",
+    },
+    {
+        action: KeyboardAction.developerToggleDebugMode,
+        accelerator: "CmdOrCtrl+D",
+    },
+];
+
+
+export function getAccleratorForAction(action: KeyboardAction): string {
+    /**
+     * Returns the accelerator for a given keyboard action
+     */
+    // Find the matching menu item by keyboardAction (should only ever return one item)
+    let matchingMenuItem = KeybindingsForMenu.filter((menuAction) => {
+        return menuAction.action === action;
+    })[0];
+    return matchingMenuItem.accelerator;
+}

--- a/src/views/menu/Menu.ts
+++ b/src/views/menu/Menu.ts
@@ -1,0 +1,185 @@
+import {KeyboardAction, SplitDirection} from "../../Enums";
+import {remote} from "electron";
+import {getAccleratorForAction} from "../keyevents/Keybindings";
+
+
+
+export function buildMenuTemplate(app: Electron.App, browserWindow: Electron.BrowserWindow): Electron.MenuItemOptions[] {
+    const template: Electron.MenuItemOptions[] = [
+        {
+            label: "Black Screen",
+            submenu: [
+                {
+                    label: "About Black Screen",
+                    role: "about",
+                },
+                {
+                    type: "separator",
+                },
+                {
+                    label: "Hide Black Screen",
+                    accelerator: getAccleratorForAction(KeyboardAction.blackScreenHide),
+                    click: () => {
+                        app.hide();
+                    },
+                },
+                {
+                    label: "Hide Others",
+                    accelerator: getAccleratorForAction(KeyboardAction.blackScreenHideOthers),
+                    role: "hideothers",
+                },
+                {
+                    type: "separator",
+                },
+                {
+                    label: "Quit",
+                    accelerator: getAccleratorForAction(KeyboardAction.blackScreenQuit),
+                    click: () => {
+                        app.quit();
+                    },
+                },
+            ],
+        },
+        {
+            label: "Edit",
+            submenu: [
+                {
+                    label: "Undo",
+                    accelerator: getAccleratorForAction(KeyboardAction.editUndo),
+                    role: "undo",
+                },
+                {
+                    label: "Redo",
+                    accelerator: getAccleratorForAction(KeyboardAction.editRedo),
+                    role: "redo",
+                },
+                {
+                    label: "Find",
+                    accelerator: getAccleratorForAction(KeyboardAction.editFind),
+                    click: () => {
+                        (document.querySelector("input[type=search]") as HTMLInputElement).select();
+                    },
+                },
+                {
+                    type: "separator",
+                },
+                {
+                    label: "Cut",
+                    accelerator: getAccleratorForAction(KeyboardAction.clipboardCut),
+                    role: "cut",
+                },
+                {
+                    label: "Copy",
+                    accelerator: getAccleratorForAction(KeyboardAction.clipboardCopy),
+                    role: "copy",
+                },
+                {
+                    label: "Paste",
+                    accelerator: getAccleratorForAction(KeyboardAction.clipboardPaste),
+                    role: "paste",
+                },
+                {
+                    label: "Select All",
+                    accelerator: getAccleratorForAction(KeyboardAction.editSelectAll),
+                    role: "selectall",
+                },
+            ],
+        },
+        {
+            label: "View",
+            submenu: [
+                {
+                    label: "Reload",
+                    accelerator: getAccleratorForAction(KeyboardAction.viewReload),
+                    click: () => {
+                        browserWindow.reload();
+                    },
+                },
+                {
+                    label: "Toggle Full Screen",
+                    accelerator: getAccleratorForAction(KeyboardAction.viewToggleFullScreen),
+                    click: () => {
+                        browserWindow.setFullScreen(!browserWindow.isFullScreen());
+                    },
+                },
+                {
+                    label: "Toggle Developer Tools",
+                    accelerator: getAccleratorForAction(KeyboardAction.developerToggleTools),
+                    click: () => {
+                        browserWindow.webContents.toggleDevTools();
+                    },
+                },
+            ],
+        },
+        {
+            label: "Window",
+            submenu: [
+                {
+                    label: "Add Tab",
+                    accelerator: getAccleratorForAction(KeyboardAction.tabNew),
+                    click: () => {
+                        window.application.addTab();
+                    },
+                },
+                {
+                    label: "Split Horizontally",
+                    accelerator: getAccleratorForAction(KeyboardAction.windowSplitHorizontally),
+                    click: () => {
+                        window.focusedTab.addPane(SplitDirection.Horizontal);
+                        window.application.forceUpdate();
+                    },
+                },
+                {
+                    label: "Split Vertically",
+                    accelerator: getAccleratorForAction(KeyboardAction.windowSplitVertically),
+                    click: () => {
+                        window.focusedTab.addPane(SplitDirection.Vertical);
+                        window.application.forceUpdate();
+                    },
+                },
+            ],
+        },
+        {
+            label: "Pane",
+            submenu: [
+                {
+                    label: "Previous",
+                    accelerator: getAccleratorForAction(KeyboardAction.tabPrevious),
+                    click: () => {
+                        window.focusedTab.activatePreviousPane();
+                        window.application.forceUpdate();
+                    },
+                },
+                {
+                    label: "Next",
+                    accelerator: getAccleratorForAction(KeyboardAction.tabNext),
+                    click: () => {
+                        window.focusedTab.activateNextPane();
+                        window.application.forceUpdate();
+                    },
+                },
+                {
+                    label: "Close",
+                    accelerator: getAccleratorForAction(KeyboardAction.tabClose),
+                    click: () => {
+                        window.application.closeFocusedPane();
+                        window.application.forceUpdate();
+                    },
+                },
+            ],
+        },
+        {
+            label: "Help",
+            submenu: [
+                {
+                    label: "GitHub Repository",
+                    click: () => {
+                        /* tslint:disable:no-unused-expression */
+                        remote.shell.openExternal("https://github.com/shockone/black-screen");
+                    },
+                },
+            ],
+        },
+    ];
+    return template;
+}


### PR DESCRIPTION
Allows editing of default keybindings by editing src/views/keyevents/Keybindings.ts
Adds menu support for Windows & Linux by using the 'CmdOrCtrl' accelerator, by default copy is bound to Ctrl+Shift+C for Windows/Linux.
All the keybinding defaults were set from the existing code.