### PR TITLE
Add inline sourcemaps to tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     "jsx": "react",
     "outDir": "compiled/src",
     "strictNullChecks": true,
-    "noImplicitThis": true
+    "noImplicitThis": true,
+    "inlineSourceMap": true
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
Inline sourcemaps output the sourcemap as a special comment at the bottom of the compiled js files. This allows debugging in TypeScript code instead of compiled JavaScript. 

In a production web environment this flag should not be used because it makes each *.js file larger. But in an electron environment it appears the size of *.js files doesn't really matter because files are loaded directly from the local device. 
https://discuss.atom.io/t/minification-of-js-css-for-atom-shell/15528

I believe this is a cleaner way than outputting *.map files and because we are using electron the file size increase has no effect on performance (micro optimization).