### PR TITLE
Fix git add autocomplete 

### DIFF
--- a/src/utils/Git.ts
+++ b/src/utils/Git.ts
@@ -39,6 +39,7 @@ function lettersToStatusCode(letters: string): StatusCode {
         case "  ":
             return StatusCode.Unmodified;
         case " M":
+        case "M ":
             return StatusCode.Modified;
         case "AM":
             return StatusCode.Added;


### PR DESCRIPTION
Fixes #741, which was caused by `Unknown git status code: "M "` interfering with the autocomplete

![image](https://cloud.githubusercontent.com/assets/558242/18378512/4b28a1a6-7622-11e6-9230-4efb0ed49832.png)
