### PR TITLE
Prevent NPM autocomplete from throwing after typing "npm install " or…

### DIFF
--- a/src/plugins/autocompletion_providers/NPM.ts
+++ b/src/plugins/autocompletion_providers/NPM.ts
@@ -228,7 +228,9 @@ PluginManager.registerAutocompletionProvider("npm", async (context) => {
                 return [];
             }
         } else {
-            throw "Has no first argument.";
+            // TODO: handle npm sub commands other than "run" that can be
+            // further auto-completed
+            return [];
         }
     } else {
         return [];


### PR DESCRIPTION
… any other sub-command besides "run"