### PR TITLE
Added ps auto-complete functionality

### DIFF
--- a/src/plugins/autocompletion_providers/Ps.ts
+++ b/src/plugins/autocompletion_providers/Ps.ts
@@ -1,0 +1,187 @@
+import {PluginManager} from "../../PluginManager";
+import {shortFlag, mapSuggestions, Suggestion, styles}
+    from "../autocompletion_utils/Common";
+import combine from "../autocompletion_utils/Combine";
+import {AutocompletionContext, AutocompletionProvider} from "../../Interfaces";
+import {mapObject} from "../../utils/Common";
+import * as Process from "../../utils/Process";
+
+// ps option suggestions based on linux  man file:
+// http://linux.die.net/man/1/ps
+const shortOptions = combine(mapObject(
+    {
+        "C": {
+            description: `Select by command name.`,
+        },
+        "G": {
+            description: `Select by real group ID (RGID) or name.`,
+        },
+        "U": {
+            description: `Select by effective user ID (EUID) or name.`,
+        },
+
+    },
+    (option, info) => {
+        return mapSuggestions(shortFlag(option),
+                              suggestion => suggestion.withDescription(info.description));
+    }
+));
+
+
+interface TokenInfo {
+    params: string[];
+    start: string;
+}
+
+const argInfo = (context: AutocompletionContext): TokenInfo => {
+        const token: string = context.argument.value;
+        const flag = token.substring(0, token.indexOf("=") + 1);
+        let params: string[] = [];
+        let start = flag;
+        if (token.includes(",")) {
+            params = token.substring(start.length, token.lastIndexOf(",")).split(",");
+            start = token.substring(0, token.lastIndexOf(",") + 1);
+        }
+        return <TokenInfo>{params: params, start: start};
+    };
+
+interface LongFlagItem {
+    flag: string;
+    description: string;
+    providers?: AutocompletionProvider;
+}
+
+const realUserSuggestions = async(context: AutocompletionContext): Promise<Suggestion[]> => {
+        const arg = argInfo(context);
+        const users = await Process.users();
+        return users
+                    .filter(i => !arg.params.includes(i.ruser))
+                    .map(i =>
+                        new Suggestion({value: arg.start + i.ruser, displayValue: i.ruser,
+                            description: `User '${i.ruser}' with id '${i.ruserid}'`,
+                            style: styles.optionValue}));
+    };
+
+const effectiveUserSuggestions = async(context: AutocompletionContext): Promise<Suggestion[]> => {
+        const arg = argInfo(context);
+        const users = await Process.users();
+        return users
+                    .filter(i => !arg.params.includes(i.euser))
+                    .map(i =>
+                        new Suggestion({value: arg.start + i.euser, displayValue: i.euser,
+                            description: `User '${i.euser}' with id '${i.euserid}'`,
+                            style: styles.optionValue}));
+    };
+
+const effectiveGroupSuggestions = async(context: AutocompletionContext): Promise<Suggestion[]> => {
+        const arg = argInfo(context);
+        const groups = await Process.groups();
+        return groups
+                    .filter(i => !arg.params.includes(i.egroup))
+                    .map(i =>
+                        new Suggestion({value: arg.start + i.egroup, displayValue: i.egroup,
+                            description: `Group '${i.egroup}' with id '${i.egroupid}'`,
+                            style: styles.optionValue}));
+    };
+
+const realGroupSuggestions = async(context: AutocompletionContext): Promise<Suggestion[]> => {
+        const arg = argInfo(context);
+        const groups = await Process.groups();
+        return groups
+                    .filter(i => !arg.params.includes(i.rgroup))
+                    .map(i =>
+                        new Suggestion({value: arg.start + i.rgroup, displayValue: i.rgroup,
+                            description: `Group '${i.rgroup}' with id '${i.rgroupid}'`,
+                            style: styles.optionValue}));
+    };
+
+const terminalSuggestions = async(context: AutocompletionContext): Promise<Suggestion[]> => {
+        const arg = argInfo(context);
+        const terminals = await Process.terminals();
+        return terminals
+                .filter(i => !arg.params.includes(i.name))
+                .map(i => new Suggestion({value: arg.start + i.name, displayValue: i.name,
+                            description: `Terminal '${i.name}' with ruser '${i.ruser}'`,
+                            style: styles.optionValue}));
+    };
+
+const processSuggestions = async(context: AutocompletionContext): Promise<Suggestion[]> => {
+        const arg = argInfo(context);
+        const processes = await Process.processes();
+        return processes
+                .filter(i => !arg.params.includes(i.pid))
+                .map(i => new Suggestion({value: arg.start + i.pid, displayValue: i.pid,
+                            description: `Process with command '${i.cmd.slice(0, 25)}' 
+                                and ruser '${i.ruser}'`,
+                            style: styles.optionValue}));
+    };
+
+const sessionSuggestions = async(context: AutocompletionContext): Promise<Suggestion[]> => {
+        const arg = argInfo(context);
+        const sessions = await Process.sessions();
+        return sessions
+                .filter(i => !arg.params.includes(i.sid))
+                .map(i => new Suggestion({value: arg.start + i.sid, displayValue: i.sid,
+                            description: `Session '${i.sid}' with ruser '${i.ruser}' 
+                                and rgroup '${i.rgroup}'`,
+                            style: styles.optionValue}));
+    };
+
+const longOptions: LongFlagItem[] = [
+    {
+        flag: "user=",
+        description: `Select by effective user ID (EUID) or name. Identical to -u and U.`,
+        providers: effectiveUserSuggestions,
+    },
+    {
+        flag: "User=",
+        description: `Select by real user ID (RUID) or name. Identical to -U.`,
+        providers: realUserSuggestions,
+    },
+    {
+        flag: "group=",
+        description: `Select by effective group ID (EGID) or name.`,
+        providers: effectiveGroupSuggestions,
+    },
+    {
+        flag: "Group=",
+        description: `Select by real group ID (RGID) or name. Identical to -G.`,
+        providers: realGroupSuggestions,
+    },
+    {
+        flag: "tty=",
+        description: `selects the processes associated with the terminals given 
+                in ttylist. Identical to -T.`,
+        providers: terminalSuggestions,
+    },
+    {
+        flag: "pid=",
+        description: `Select by process ID. Identical to -p and p.`,
+        providers: processSuggestions,
+    },
+    {
+        flag: "sid=",
+        description: `Select by session ID. Identical to -s.`,
+        providers: sessionSuggestions,
+    },
+];
+
+const longFlagSuggestions = async(context: AutocompletionContext): Promise<Suggestion[]> => {
+        let suggestions: Suggestion[] = [];
+        const token: string = context.argument.value;
+        for (let i of longOptions) {
+            const flag = "--" + i.flag;
+            suggestions.push(new Suggestion({value: flag,
+                                    displayValue: flag, description: i.description,
+                                    style: styles.option}));
+            if (i.providers && token.startsWith(flag)) {
+                let providerSuggestions = await i.providers(context);
+                suggestions = [...suggestions, ...providerSuggestions];
+            }
+        }
+        return suggestions;
+    };
+
+const psSuggestions = combine([shortOptions, longFlagSuggestions]);
+
+PluginManager.registerAutocompletionProvider("ps", psSuggestions);

--- a/src/utils/Process.ts
+++ b/src/utils/Process.ts
@@ -1,0 +1,85 @@
+import {executeCommandWithShellConfig} from "../PTY";
+import {intersection} from "lodash";
+
+// http://linuxcommand.org/man_pages/ps1.html
+
+export interface User {
+    ruserid: string;
+    ruser: string;
+    euserid: string;
+    euser: string;
+}
+
+export interface Group {
+    rgroupid: string;
+    rgroup: string;
+    egroupid: string;
+    egroup: string;
+}
+
+export interface Terminal {
+    name: string;
+    ruser: string;
+}
+
+export interface Process {
+    pid: string;
+    time: string;
+    ruser: string;
+    cmd: string;
+}
+
+export interface Session {
+    sid: string;
+    ruser: string;
+    rgroup: string;
+}
+
+const ignoreUsers: string[] = ["nobody"];
+
+const ignoreGroups: string[] = ["nobody"];
+
+const resultSet = (result: string[]) => {
+        const numColumns = result[0].trim().replace(/ +(?= )/g, "").split(" ").length;
+        return result.splice(1)
+                     .map(i => i.trim().replace(/ +(?= )/g, "").split(" ", numColumns));
+    };
+
+export const users =
+    async(): Promise<User[]> => {
+        const pInfo: string[][] =
+                resultSet(await executeCommandWithShellConfig("ps -eo ruid,ruser,euid,euser"));
+        return pInfo.map(p => <User> {ruserid: p[0], ruser: p[1], euserid: p[2], euser: p[3]})
+                    .filter(p => intersection(ignoreUsers, [p.ruser, p.euser]).length === 0);
+    };
+
+export const groups =
+    async(): Promise<Group[]> => {
+    const pInfo: string[][] =
+            resultSet(await executeCommandWithShellConfig("ps -eo rgid,rgroup,egid,egroup"));
+    return pInfo.map(p => <Group> {rgroupid: p[0], rgroup: p[1], egroupid: p[2], egroup: p[3]})
+                .filter(p => intersection(ignoreGroups, [p.rgroup, p.egroup]).length === 0);
+    };
+
+export const terminals =
+    async(): Promise<Terminal[]> => {
+        const pInfo: string[][] =
+                resultSet(await executeCommandWithShellConfig("ps -eo tty,ruser"));
+        return pInfo.filter(p => p[0] !== "?")
+                    .map(p => <Terminal> {name: p[0], ruser: p[1]});
+    };
+
+export const processes =
+    async(): Promise<Process[]> => {
+        const pInfo: string[][] =
+                resultSet(await executeCommandWithShellConfig("ps -eo pid,time,ruser,cmd"));
+        return pInfo.map(p => <Process> {pid: p[0], time: p[1], ruser: p[2], cmd: p[3]});
+    };
+
+export const sessions =
+    async(): Promise<Session[]> => {
+    const pInfo: string[][] =
+            resultSet(await executeCommandWithShellConfig("ps -eo sid,ruser,rgroup"));
+    return pInfo.map(p => <Session> {sid: p[0], rgroup: p[1]});
+};
+


### PR DESCRIPTION
This PR provides auto-complete functionality for the "ps" command and some of the the options available.

The long-flag options provide suggested values based on the values available. These values can be chained together separated by commas. The example in the screenshot attached is for the "--pid" (process id) option and shows a number of values entered separated by commas. 
![image](https://cloud.githubusercontent.com/assets/12181805/18607085/8438548e-7d05-11e6-95d7-c0a325029c91.png)

I would like to cache calls for long-flag option to save multiple calls to fetch available options. In the "src/utils/Process.ts" file I attempted to do this by using memoize to cache the results of the processes function (see annotation inline). Unfortunately the result is cached for the entire terminal session - I need to cache this for each terminal command instance (if that makes sense).

Please let me know if you can think of any ways of caching per command instance.