### PR TITLE
Force shells to be interactive

### DIFF
--- a/src/PTY.ts
+++ b/src/PTY.ts
@@ -12,7 +12,7 @@ export class PTY {
     // TODO: use generators.
     // TODO: terminate. https://github.com/atom/atom/blob/v1.0.15/src/task.coffee#L151
     constructor(words: EscapedShellWord[], env: ProcessEnvironment, dimensions: Dimensions, dataHandler: (d: string) => void, exitHandler: (c: number) => void) {
-        const shellArguments = [...loginShell.noConfigSwitches, "-c", words.join(" ")];
+        const shellArguments = [...loginShell.noConfigSwitches, "-i", "-c", words.join(" ")];
 
         debug(`PTY: ${loginShell.executableName} ${JSON.stringify(shellArguments)}`);
 


### PR DESCRIPTION
I have this in my `~/.profile`:

```bash
function s() {
    # Is stdin a terminal?
    if [[ -t 0 ]]
    then
        #not piping
        subl "$@" &
    else
        #piping
        contents=$(cat)
        subl "$@" <<< "$contents" &
    fi
}
export -f s
```

It doesn't work unless I make the following change. I'm not exactly sure why, but also the "interactive" flag does seem to be appropriate for `black-screen`, since the launched programs are, in fact, interactive.