### PR TITLE
Tab navigation

### DIFF
--- a/src/Enums.ts
+++ b/src/Enums.ts
@@ -115,9 +115,9 @@ export enum KeyboardAction {
     // tab commands
     tabNew,
     tabFocus,
-    tabPrevious,
-    tabNext,
-    tabClose,
+    panePrevious,
+    paneNext,
+    paneClose,
     // edit/clipboard commands
     clipboardCopy,
     clipboardCut,

--- a/src/Enums.ts
+++ b/src/Enums.ts
@@ -115,6 +115,10 @@ export enum KeyboardAction {
     // tab commands
     tabNew,
     tabFocus,
+    tabPrevious,
+    tabNext,
+    tabClose,
+    // pane commands
     panePrevious,
     paneNext,
     paneClose,

--- a/src/views/1_ApplicationComponent.tsx
+++ b/src/views/1_ApplicationComponent.tsx
@@ -81,21 +81,21 @@ export class ApplicationComponent extends React.Component<{}, {}> {
 
     activatePreviousTab() {
         let newPosition = this.focusedTabIndex - 1;
-        
+
         if (newPosition < 0) {
             newPosition = this.tabs.length - 1;
         }
-        
+
         this.focusTab(newPosition + 1);
     }
 
     activateNextTab() {
         let newPosition = this.focusedTabIndex + 1;
-        
+
         if (newPosition >= this.tabs.length) {
             newPosition = 0;
         }
-        
+
         this.focusTab(newPosition + 1);
     }
 

--- a/src/views/1_ApplicationComponent.tsx
+++ b/src/views/1_ApplicationComponent.tsx
@@ -73,6 +73,32 @@ export class ApplicationComponent extends React.Component<{}, {}> {
         window.focusedTab = this.focusedTab;
     }
 
+    closeFocusedTab() {
+        this.closeTab(this.focusedTab);
+
+        this.forceUpdate();
+    }
+
+    activatePreviousTab() {
+        let newPosition = this.focusedTabIndex - 1;
+        
+        if (newPosition < 0) {
+            newPosition = this.tabs.length - 1;
+        }
+        
+        this.focusTab(newPosition + 1);
+    }
+
+    activateNextTab() {
+        let newPosition = this.focusedTabIndex + 1;
+        
+        if (newPosition >= this.tabs.length) {
+            newPosition = 0;
+        }
+        
+        this.focusTab(newPosition + 1);
+    }
+
     // FIXME: this method should be private.
     closeFocusedPane() {
         this.focusedTab.closeFocusedPane();

--- a/src/views/UserEventsHander.ts
+++ b/src/views/UserEventsHander.ts
@@ -37,7 +37,7 @@ export const handleUserEvent = (application: ApplicationComponent,
         }
 
         // Close focused pane
-        if (isKeybindingForEvent(event, KeyboardAction.tabClose) && !isInProgress(job)) {
+        if (isKeybindingForEvent(event, KeyboardAction.paneClose) && !isInProgress(job)) {
             application.closeFocusedPane();
 
             application.forceUpdate();

--- a/src/views/keyevents/Keybindings.ts
+++ b/src/views/keyevents/Keybindings.ts
@@ -124,6 +124,18 @@ export const KeybindingsForMenu: KeybindingMenuType[] = [
         accelerator: "CmdOrCtrl+T",
     },
     {
+        action: KeyboardAction.tabPrevious,
+        accelerator: "Ctrl+Shift+Tab",
+    },
+    {
+        action: KeyboardAction.tabNext,
+        accelerator: "Ctrl+Tab",
+    },
+    {
+        action: KeyboardAction.tabClose,
+        accelerator: "CmdOrCtrl+Shift++W",
+    },
+    {
         action: KeyboardAction.panePrevious,
         accelerator: "CmdOrCtrl+K",
     },

--- a/src/views/keyevents/Keybindings.ts
+++ b/src/views/keyevents/Keybindings.ts
@@ -76,11 +76,12 @@ export const KeybindingsForActions: KeybindingType[] = [
             return (e.ctrlKey && e.keyCode === KeyCode.N) || (e.keyCode === KeyCode.Down);
         },
     },
-    // tab commands
+    // pane command
     {
-        action: KeyboardAction.tabClose,
+        action: KeyboardAction.paneClose,
         keybinding: (e: KeyboardEvent) => isMeta(e) && e.keyCode === KeyCode.D,
     },
+    // tab commands
     {
         action: KeyboardAction.tabFocus,
         keybinding: (e: KeyboardEvent) => {
@@ -123,15 +124,15 @@ export const KeybindingsForMenu: KeybindingMenuType[] = [
         accelerator: "CmdOrCtrl+T",
     },
     {
-        action: KeyboardAction.tabPrevious,
+        action: KeyboardAction.panePrevious,
         accelerator: "CmdOrCtrl+K",
     },
     {
-        action: KeyboardAction.tabNext,
+        action: KeyboardAction.paneNext,
         accelerator: "CmdOrCtrl+J",
     },
     {
-        action: KeyboardAction.tabClose,
+        action: KeyboardAction.paneClose,
         accelerator: "CmdOrCtrl+W",
     },
     // edit/clipboard commands

--- a/src/views/keyevents/Keybindings.ts
+++ b/src/views/keyevents/Keybindings.ts
@@ -84,7 +84,7 @@ export const KeybindingsForActions: KeybindingType[] = [
     {
         action: KeyboardAction.tabFocus,
         keybinding: (e: KeyboardEvent) => {
-            return (e.ctrlKey && e.keyCode >= KeyCode.One && e.keyCode <= KeyCode.Nine);
+            return ((e.ctrlKey || isMeta(e)) && e.keyCode >= KeyCode.One && e.keyCode <= KeyCode.Nine);
         },
     },
     // search commands

--- a/src/views/keyevents/Keybindings.ts
+++ b/src/views/keyevents/Keybindings.ts
@@ -133,7 +133,7 @@ export const KeybindingsForMenu: KeybindingMenuType[] = [
     },
     {
         action: KeyboardAction.tabClose,
-        accelerator: "CmdOrCtrl+Shift++W",
+        accelerator: "CmdOrCtrl+W",
     },
     {
         action: KeyboardAction.panePrevious,
@@ -145,7 +145,7 @@ export const KeybindingsForMenu: KeybindingMenuType[] = [
     },
     {
         action: KeyboardAction.paneClose,
-        accelerator: "CmdOrCtrl+W",
+        accelerator: "CmdOrCtrl+P",
     },
     // edit/clipboard commands
     {

--- a/src/views/menu/Menu.ts
+++ b/src/views/menu/Menu.ts
@@ -144,7 +144,7 @@ export function buildMenuTemplate(app: Electron.App, browserWindow: Electron.Bro
             submenu: [
                 {
                     label: "Previous",
-                    accelerator: getAcceleratorForAction(KeyboardAction.tabPrevious),
+                    accelerator: getAcceleratorForAction(KeyboardAction.panePrevious),
                     click: () => {
                         window.focusedTab.activatePreviousPane();
                         window.application.forceUpdate();
@@ -152,7 +152,7 @@ export function buildMenuTemplate(app: Electron.App, browserWindow: Electron.Bro
                 },
                 {
                     label: "Next",
-                    accelerator: getAcceleratorForAction(KeyboardAction.tabNext),
+                    accelerator: getAcceleratorForAction(KeyboardAction.paneNext),
                     click: () => {
                         window.focusedTab.activateNextPane();
                         window.application.forceUpdate();
@@ -160,7 +160,7 @@ export function buildMenuTemplate(app: Electron.App, browserWindow: Electron.Bro
                 },
                 {
                     label: "Close",
-                    accelerator: getAcceleratorForAction(KeyboardAction.tabClose),
+                    accelerator: getAcceleratorForAction(KeyboardAction.paneClose),
                     click: () => {
                         window.application.closeFocusedPane();
                         window.application.forceUpdate();

--- a/src/views/menu/Menu.ts
+++ b/src/views/menu/Menu.ts
@@ -112,15 +112,50 @@ export function buildMenuTemplate(app: Electron.App, browserWindow: Electron.Bro
             ],
         },
         {
-            label: "Window",
+            label: "Tab",
             submenu: [
                 {
-                    label: "Add Tab",
+                    label: "New Tab",
                     accelerator: getAcceleratorForAction(KeyboardAction.tabNew),
                     click: () => {
                         window.application.addTab();
                     },
                 },
+                {
+                    type: "separator",
+                },
+                {
+                    label: "Previous",
+                    accelerator: getAcceleratorForAction(KeyboardAction.tabPrevious),
+                    click: () => {
+                        window.application.activatePreviousTab();
+                        window.application.forceUpdate();
+                    },
+                },
+                {
+                    label: "Next",
+                    accelerator: getAcceleratorForAction(KeyboardAction.tabNext),
+                    click: () => {
+                        window.application.activateNextTab();
+                        window.application.forceUpdate();
+                    },
+                },
+                {
+                    type: "separator",
+                },
+                {
+                    label: "Close",
+                    accelerator: getAcceleratorForAction(KeyboardAction.tabClose),
+                    click: () => {
+                        window.application.closeFocusedTab();
+                        window.application.forceUpdate();
+                    },
+                },
+            ],
+        },
+        {
+            label: "Pane",
+            submenu: [
                 {
                     label: "Split Horizontally",
                     accelerator: getAcceleratorForAction(KeyboardAction.windowSplitHorizontally),
@@ -137,11 +172,9 @@ export function buildMenuTemplate(app: Electron.App, browserWindow: Electron.Bro
                         window.application.forceUpdate();
                     },
                 },
-            ],
-        },
-        {
-            label: "Pane",
-            submenu: [
+                {
+                    type: "separator",
+                },
                 {
                     label: "Previous",
                     accelerator: getAcceleratorForAction(KeyboardAction.panePrevious),
@@ -157,6 +190,9 @@ export function buildMenuTemplate(app: Electron.App, browserWindow: Electron.Bro
                         window.focusedTab.activateNextPane();
                         window.application.forceUpdate();
                     },
+                },
+                {
+                    type: "separator",
                 },
                 {
                     label: "Close",


### PR DESCRIPTION
Hi, you have an awesome app, just noticed it couple of days ago and no I'm hooked!

One thing I was missing was the tab navigation (prev/next) functionality, I took the liberty to implement it, I tried to follow the code style and tested it manually on MacOS 10.11.6. You did a great work and the source code is very readable, so it took couple of hours to implement the feature, the development environment worked without glitches. I would recommend to switch to stateless components design model though, as it seem like the app has high view-logic dependencies.

If your looking for collaborators, I'm up for the task, I have experience with nodejs, electron, react and typescript.

P.S
I also bound the meta key to the indexed tab switch (keeping the old ctrl bind in tact), the tab header place the meta key icon next to the tab index so UX wise the user expect to use it for the index tab switching (I had to peek at the source code to find the ctrl+index binding), apart from that MacOS bind ctrl+index to workspace switching so switching to the first tab was impossible for me.