### PR TITLE
Improve handling of failing interceptor plugins

### DIFF
--- a/src/plugins/Ls.tsx
+++ b/src/plugins/Ls.tsx
@@ -76,6 +76,7 @@ PluginManager.registerCommandInterceptorPlugin({
                 }
             });
         });
+
         return <LSComponent files={files} />;
     },
 


### PR DESCRIPTION
Now if the interceptor fails, it will fall back to the original command that was supposed to be intercepted.