### PR TITLE
Fix alt key

### DIFF
--- a/src/shell/Job.ts
+++ b/src/shell/Job.ts
@@ -113,7 +113,19 @@ export class Job extends EmitterWithUniqueID implements TerminalLikeDevice {
         if (typeof input === "string") {
             text = input;
         } else {
-            text = input.ctrlKey ? String.fromCharCode(input.keyCode - 64) : normalizeKey(input.key, this.screenBuffer.cursorKeysMode);
+            if (input.ctrlKey) {
+                text = String.fromCharCode(input.keyCode - 64);
+            } else if (input.altKey) {
+                let char = String.fromCharCode(input.keyCode);
+                if (input.shiftKey) {
+                    char = char.toUpperCase();
+                } else {
+                    char = char.toLowerCase();
+                }
+                text = `\x1b${char}`;
+            } else {
+                text = normalizeKey(input.key, this.screenBuffer.cursorKeysMode);
+            }
         }
 
         this.command.write(text);


### PR DESCRIPTION
I'm not 100% sure about this fix. It causes `sleep 10` then `alt+d` to display the same thing as in `iTerm` when in "Alt key = ESC+" mode. I was never able to make vim work the way @Alok described in either `black-screen` or `iTerm`. @shockone would you be able to review this one? I'm not very familiar with the ANSI/escape codes stuff.